### PR TITLE
Add Relative Links

### DIFF
--- a/website/_layouts/default.html
+++ b/website/_layouts/default.html
@@ -16,10 +16,10 @@
         </button>
         <div class="collapse navbar-collapse" id="navbarNav">
             <ul class="navbar-nav ms-auto">
-                <li class="nav-item"><a class="nav-link" href="/docs">Docs</a></li>
-                <li class="nav-item"><a class="nav-link" href="/how-tos">How-Tos</a></li>
-                <li class="nav-item"><a class="nav-link" href="/about">About</a></li>
-                <li class="nav-item"><a class="nav-link" href="/community">Community</a></li>
+                <li class="nav-item"><a class="nav-link" href="{{ '/docs' | relative_url }}">Docs</a></li>
+                <li class="nav-item"><a class="nav-link" href="{{ '/how-tos' | relative_url }}">How-Tos</a></li>
+                <li class="nav-item"><a class="nav-link" href="{{ '/about' | relative_url }}">About</a></li>
+                <li class="nav-item"><a class="nav-link" href="{{ '/community' | relative_url }}">Community</a></li>
             </ul>
         </div>
     </div>

--- a/website/_layouts/default.html
+++ b/website/_layouts/default.html
@@ -10,7 +10,7 @@
 <body>
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
     <div class="container">
-        <a class="navbar-brand" href="/">Gofannon</a>
+        <a class="navbar-brand" href="{{ '/' | relative_url}}">Gofannon</a>
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
             <span class="navbar-toggler-icon"></span>
         </button>

--- a/website/_layouts/docs.html
+++ b/website/_layouts/docs.html
@@ -16,10 +16,10 @@
         </button>
         <div class="collapse navbar-collapse" id="navbarNav">
             <ul class="navbar-nav ms-auto">
-                <li class="nav-item"><a class="nav-link" href="/docs">Docs</a></li>
-                <li class="nav-item"><a class="nav-link" href="/how-tos">How-Tos</a></li>
-                <li class="nav-item"><a class="nav-link" href="/about">About</a></li>
-                <li class="nav-item"><a class="nav-link" href="/community">Community</a></li>
+                <li class="nav-item"><a class="nav-link" href="{{ '/docs' | relative_url }}">Docs</a></li>
+                <li class="nav-item"><a class="nav-link" href="{{ '/how-tos' | relative_url }}">How-Tos</a></li>
+                <li class="nav-item"><a class="nav-link" href="{{ '/about' | relative_url }}">About</a></li>
+                <li class="nav-item"><a class="nav-link" href="{{ '/community' | relative_url }}">Community</a></li>
             </ul>
         </div>
     </div>
@@ -27,13 +27,11 @@
 
 <main class="container mt-4">
     <div class="row">
-        <!-- Sidebar for navigation -->
         <aside class="col-md-3">
             <div class="list-group sticky-top">
-                <!-- Example of static links, replace with dynamic content as needed -->
-                <a href="/docs/index.html" class="list-group-item list-group-item-action">Home</a>
-                <a href="/docs/cross-framework_compatibility.html" class="list-group-item list-group-item-action">Cross Framework Compatability</a>
-                <a href="/docs/how_to_contribute.html" class="list-group-item list-group-item-action">How To Contribute a New Tool</a>
+                <a href="{{ '/docs/index.html' | relative_url }}" class="list-group-item list-group-item-action">Home</a>
+                <a href="{{ '/docs/cross-framework_compatibility.html' | relative_url }}" class="list-group-item list-group-item-action">Cross Framework Compatability</a>
+                <a href="{{ '/docs/how_to_contribute.html' | relative_url }}" class="list-group-item list-group-item-action">How To Contribute a New Tool</a>
             </div>
         </aside>
 

--- a/website/_layouts/docs.html
+++ b/website/_layouts/docs.html
@@ -10,7 +10,7 @@
 <body>
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
     <div class="container">
-        <a class="navbar-brand" href="/">Gofannon</a>
+        <a class="navbar-brand" href="{{ '/' | relative_url}}">Gofannon</a>
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
             <span class="navbar-toggler-icon"></span>
         </button>

--- a/website/how-tos/first_contribution.md
+++ b/website/how-tos/first_contribution.md
@@ -70,7 +70,7 @@ Welcome to the Gofannon community! This guide will walk you through making your 
    ```
 
 2. **Make Your Changes**
-    - Follow the [contribution guidelines](CONTRIBUTING.md)
+    - Follow the [contribution guidelines](https://github.com/The-AI-Alliance/gofannon/blob/main/CONTRIBUTING.md)
     - Write tests for your changes
     - Update documentation if needed
 

--- a/website/how-tos/index.md
+++ b/website/how-tos/index.md
@@ -7,7 +7,7 @@ title: How-Tos
 
 Our how-to section is currently being forged in the fires of development! Check back soon for:
 
-- **[Making Your First Commit](how-tos/first_contribution.html)**: Making your first commit to open source can be intimidating. This guide can help.
+- **[Making Your First Commit]({{ 'how-tos/first_contribution.html' | relative_url }})**: Making your first commit to open source can be intimidating. This guide can help.
 - **Framework Integration Guides**: Step-by-step tutorials for LangChain, AWS, and more
 - **Contribution Workshops**: Learn open source practices through hands-on examples
 - **Tool Development Masterclass**: From idea to merged PR in 10 steps

--- a/website/index.md
+++ b/website/index.md
@@ -7,7 +7,7 @@ title: Home
     <div class="container text-center">  
         <h1 class="display-4">Gofannon Tools</h1>  
         <p class="lead">Forging next-generation AI capabilities</p>  
-        <a href="/docs" class="btn btn-light btn-lg">Get Started</a>  
+        <a href="{{ '/docs' | relative_url }}" class="btn btn-light btn-lg">Get Started</a>  
     </div>  
 </div>  
 
@@ -23,7 +23,7 @@ title: Home
         <div class="col-md-6">  
             <h2>Open Source Education</h2>  
             <p>Learn AI development through practical contributions. We provide mentorship and guided pathways for new contributors.</p>  
-            <a href="/how-tos" class="btn btn-outline-primary">Contribution Guide</a>  
+            <a href="{{ '/how-tos' | relative_url }}" class="btn btn-outline-primary">Contribution Guide</a>  
         </div>  
     </div>  
 </div>  

--- a/website/scripts/sync_docs.py
+++ b/website/scripts/sync_docs.py
@@ -12,8 +12,13 @@ title: {title}
 """
 
 def replace_md_with_html(content):
-    # Regular expression to find markdown links
-    return re.sub(r"(\]\()(.*?)(\.md)(\))", r"\1\2.html\4", content)
+    # Match internal links (not starting with http:// or https://)
+    pattern = re.compile(
+        r'(\]\()((?!https?://)(.*?))\.md(\))',
+        flags=re.IGNORECASE
+    )
+    # Replace with HTML extension and relative_url filter
+    return pattern.sub(r'\1{{ "\2.html" | relative_url }}\4', content)
 
 def process_md_files(src, dest):
     for item in os.listdir(src):

--- a/website/scripts/sync_docs.py
+++ b/website/scripts/sync_docs.py
@@ -1,50 +1,77 @@
+#!/usr/bin/env python3  
 import os
 import shutil
 from pathlib import Path
 import re
+import posixpath
 
 DOCS_SOURCE = Path("docs")
 DOCS_TARGET = Path("website/docs")
-JEKYLL_HEADER = """---    
-layout: docs    
-title: {title}    
----    
+JEKYLL_HEADER = """---      
+layout: docs      
+title: {title}      
+---      
 """
 
-def replace_md_with_html(content):
-    # Match internal links (not starting with http:// or https://)
-    pattern = re.compile(
-        r'(\]\()((?!https?://)(.*?))\.md(\))',
-        flags=re.IGNORECASE
-    )
-    # Replace with HTML extension and relative_url filter
-    return pattern.sub(r'\1{{ "\2.html" | relative_url }}\4', content)
+# This function takes the content of a markdown file and the file’s current  
+# relative directory (relative to the docs root) and replaces internal markdown links  
+# (links ending with .md) with links that use the relative_url filter and an absolute docs path.  
+# External links (those starting with http:// or https://) are left unchanged.  
+def replace_md_with_html(content, current_rel_dir):
+    # Pattern: Match links that are NOT external and end with .md.  
+    # Group members:  
+    #   Group(1) - the literal "]("  
+    #   Group(2) - the link URL without the .md extension  
+    #   Group(3) - the closing ")"  
+    pattern = re.compile(r'(\]\()((?!https?://)[^)\s]+?)\.md(\))', flags=re.IGNORECASE)
 
-def process_md_files(src, dest):
+    def repl(match):
+        link = match.group(2).strip()
+        # If the link is relative (does not start with a slash), join it with the current relative directory.  
+        if not link.startswith("/"):
+            # Create an absolute path relative to the docs root.  
+            abs_path = posixpath.normpath(posixpath.join("/docs", current_rel_dir, link))
+        else:
+            # If already absolute, just normalize the path.  
+            abs_path = posixpath.normpath(link)
+            # Add the .html extension, as it will be converted in the site.
+        abs_path += ".html"
+        # Return a new markdown link using Jekyll’s relative_url filter.  
+        return f'{match.group(1)}{{{{ "{abs_path}" | relative_url }}}}{match.group(3)}'
+
+    return pattern.sub(repl, content)
+
+# Processes markdown files recursively.  
+# "rel_dir" is a string representing the current directory relative to DOCS_SOURCE using POSIX-style paths.  
+def process_md_files(src: Path, dest: Path, rel_dir=""):
     for item in os.listdir(src):
         src_path = src / item
         dest_path = dest / item
 
         if src_path.is_dir():
+            # Compute new relative directory for files in subdirectories.  
+            new_rel_dir = posixpath.join(rel_dir, item) if rel_dir else item
             dest_path.mkdir(exist_ok=True)
-            process_md_files(src_path, dest_path)
-        elif src_path.suffix == ".md":
-            with open(src_path, "r") as f:
+            process_md_files(src_path, dest_path, new_rel_dir)
+        elif src_path.suffix.lower() == ".md":
+            with open(src_path, "r", encoding="utf-8") as f:
                 content = f.read()
 
-                # Replace .md references with .html
-            content = replace_md_with_html(content)
+                # Replace markdown links with converted links.
+            content = replace_md_with_html(content, rel_dir)
 
+            # Use the filename (without ".md") as the title.  
             title = item[:-3].replace("_", " ").title()
             new_content = JEKYLL_HEADER.format(title=title) + content
 
-            with open(dest_path, "w") as f:
+            with open(dest_path, "w", encoding="utf-8") as f:
                 f.write(new_content)
 
 if __name__ == "__main__":
     if DOCS_TARGET.exists():
         shutil.rmtree(DOCS_TARGET)
-    DOCS_TARGET.mkdir()
+    DOCS_TARGET.mkdir(parents=True, exist_ok=True)
 
     process_md_files(DOCS_SOURCE, DOCS_TARGET)
-    print(f"Processed {len(list(DOCS_TARGET.glob('**/*.md')))} documentation files")
+    num_files = len(list(DOCS_TARGET.glob("**/*.md")))
+    print(f"Processed {num_files} documentation files")  


### PR DESCRIPTION
# PR Template: New Function or Feature

## Description of Changes
Adds 'relative_link'. In html that is:
`<a class="nav-link" href="/about">About</a>`
becomes
`<a class="nav-link" href="{{ '/about' | relative_url }}">About</a> `

In markdown: `[About](about.md)` becomes `[About]({{ '/about' | relative_url }})`

I also updated the doc_sync script, so that links in docs will be updated when synced to the website - both adding the `relative_url` tag and facing the relative path. 



## Related Issues
List any related issues or PRs that this submission addresses:
Closes #50

## Testing Performed
Clicking around on test build of site hosted on my machine

## Code Changes
All files in website with a link, and sync_files.py

## Example Usage
n/a

## Checklist
Confirm that the following have been completed:

* [x] All new functions have been documented in the `docs/` directory
* [x] New functions have been added to the `ROADMAP.md` file
* [x] Unit tests have been added for new functions
* [x] Code follows the existing style and convention
* [x] API keys or sensitive information have been removed

## Additional Context
Any additional context or information that might be helpful for reviewers:

* Relevant discussions or meetings
* Open questions or areas for further discussion  