### PR TITLE
remove config.yml

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/config.yml
+++ b/.github/PULL_REQUEST_TEMPLATE/config.yml
@@ -1,9 +1,0 @@
-blank_issues_enabled: true
-
-choices:
-  - name: "Documentation/Website Change"
-    description: "For changes to documentation or website content"
-    file: "docs_website_pr.md"
-  - name: "New Function or Feature"
-    description: "For proposing a new function or tool"
-    file: "general_code_pr.md"


### PR DESCRIPTION
Confirm PR templates 'work' now. (Hack, but that's github's fault)

Closes #79 