### PR TITLE
Add bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,43 @@
+---  
+name: Bug Report  
+about: Report a bug or unexpected behavior  
+title: "[Bug] "  
+labels: bug  
+assignees: ''
+  
+---  
+
+## Bug Description
+A clear and concise description of what the bug is.
+
+### Steps to Reproduce
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '...'
+3. Scroll down to '...'
+4. See error
+
+### Expected Behavior
+A clear and concise description of what you expected to happen.
+
+### Actual Behavior
+A clear and concise description of what actually happened.
+
+### Screenshots
+If applicable, add screenshots to help explain your problem.
+
+### Environment
+- OS: [e.g. Windows 10, macOS 12.6, Ubuntu 22.04]
+- Python Version: [e.g. 3.10.8]
+- Package Version: [e.g. 0.23.1]
+
+### Additional Context
+Add any other context about the problem here.
+  
+---  
+
+## Contribution Checklist
+- [ ] I have searched existing issues to ensure this bug hasn't been reported
+- [ ] I have provided clear reproduction steps
+- [ ] I have included relevant environment details
+- [ ] I have described both expected and actual behavior  

--- a/.github/ISSUE_TEMPLATE/generic_issue.md
+++ b/.github/ISSUE_TEMPLATE/generic_issue.md
@@ -1,36 +1,33 @@
 ---  
-name: General Issue  
-about: Report a bug, ask a question, or request a feature  
-title: "[Issue] "  
-labels: ""  
+name: General Issue    
+about: Ask a question or request a feature    
+title: "[Issue] "    
+labels: ""    
 assignees: ''
-  
----  
+    
+---    
 
 ## Description
-Please provide a clear and concise description of the issue you're experiencing or the question you have.
+Please provide a clear and concise description of the question you have or feature you're requesting.
 
-### Steps to Reproduce (if applicable)
-If this is a bug report, please provide the steps to reproduce the issue:
-1. Step 1
-2. Step 2
-3. Step 3
+### Feature Details (if applicable)
+If this is a feature request, please describe:
+- What you want to happen
+- Why this would be valuable
+- Any alternative solutions you've considered
 
-### Expected Behavior
-What is the expected behavior?
-
-### Actual Behavior
-What is the actual behavior?
-
-### Error Messages (if applicable)
-Please include any error messages you've encountered.
+### Question Details (if applicable)
+If this is a question, please provide:
+- What you're trying to accomplish
+- What you've tried so far
+- Any relevant code snippets
 
 ### Additional Context
-Add any other context or screenshots that might be helpful in resolving the issue.
-  
----  
+Add any other context or screenshots that might be helpful.
+    
+---    
 
 ## Checklist
 - [ ] I have searched the existing issues to ensure this isn't a duplicate
 - [ ] I have checked the documentation and README for a solution
-- [ ] I have provided clear and concise information about the issue  
+- [ ] I have provided clear and concise information about the issue    

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -3,15 +3,15 @@
 name-template: 'v$NEXT_PATCH_VERSION 🎉'
 tag-template: 'v$NEXT_PATCH_VERSION'
 categories:
-  - title: '🛠 Frameworks and Tools'
-    labels:
-      - 'framework'
-      - 'enhancement'
-
   - title: '🐛 Bug Fixes'
     labels:
       - 'bug'
       - 'fix'
+
+  - title: '🛠 Frameworks and Tools'
+    labels:
+      - 'framework'
+      - 'enhancement'
 
   - title: '🤖 Maintenance and Automation'
     labels:
@@ -32,4 +32,4 @@ template: |
 
   $CHANGES
 
-  **Full Changelog**: https://github.com/$OWNER/$REPO/compare/$PREVIOUS_TAG...$NEW_TAG
+  **Full Changelog**: https://github.com/$OWNER/$REPO/compare/$PREVIOUS_TAG...$NEW_TAG  


### PR DESCRIPTION
# PR Template: Documentation/Website Change  
  
## Description of Changes  
Added a dedicated bug report issue template to improve bug reporting consistency and quality.  
  
* Added new `.github/ISSUE_TEMPLATE/bug_report.md` file  
* Updated `.github/ISSUE_TEMPLATE/generic_issue.md` to focus on questions/features  
* Updated `.github/release-drafter.yml` to ensure bugs appear first in release notes  
  
## Related Issues  
* Closes #178 
  
## Testing Performed  
- [x] Verified templates render correctly in GitHub UI  
- [x] Checked that new bug label is properly categorized in release drafter  
  
## Code Changes  
List all files modified/added:  
* .github/ISSUE_TEMPLATE/bug_report.md (new)  
* .github/ISSUE_TEMPLATE/generic_issue.md (updated)  
* .github/release-drafter.yml (updated)  
  
## Checklist  
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide  
- [x] My changes follow the documentation style guide  
- [x] I have updated any related documentation  
- [x] I have included necessary screenshots or examples  
  
## Additional Context  
This change was requested by several community members who wanted more structured bug reporting.  