### PR TITLE
[Bug] Example pip install points to old branch

### DIFF
--- a/examples/Complex_Math.ipynb
+++ b/examples/Complex_Math.ipynb
@@ -8,7 +8,7 @@
           "base_uri": "https://localhost:8080/"
         },
         "id": "ujvVmMa0btJb",
-        "outputId": "1b39b878-5871-462d-e908-cba76a728a99"
+        "outputId": "05dc52d8-580d-44d5-cafe-88ad63a72886"
       },
       "outputs": [
         {
@@ -18,29 +18,14 @@
             "  Installing build dependencies ... \u001b[?25l\u001b[?25hdone\n",
             "  Getting requirements to build wheel ... \u001b[?25l\u001b[?25hdone\n",
             "  Preparing metadata (pyproject.toml) ... \u001b[?25l\u001b[?25hdone\n",
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m57.7/57.7 kB\u001b[0m \u001b[31m3.1 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m389.6/389.6 kB\u001b[0m \u001b[31m11.6 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m76.4/76.4 kB\u001b[0m \u001b[31m4.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m78.6/78.6 kB\u001b[0m \u001b[31m4.5 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m96.0/96.0 kB\u001b[0m \u001b[31m5.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m207.6/207.6 kB\u001b[0m \u001b[31m11.4 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m70.4/70.4 kB\u001b[0m \u001b[31m4.5 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m345.6/345.6 kB\u001b[0m \u001b[31m19.4 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m431.7/431.7 kB\u001b[0m \u001b[31m22.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m2.0/2.0 MB\u001b[0m \u001b[31m47.6 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m78.5/78.5 kB\u001b[0m \u001b[31m4.4 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m164.9/164.9 kB\u001b[0m \u001b[31m9.6 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m62.8/62.8 kB\u001b[0m \u001b[31m3.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m58.3/58.3 kB\u001b[0m \u001b[31m3.0 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25h  Building wheel for gofannon (pyproject.toml) ... \u001b[?25l\u001b[?25hdone\n",
-            "\u001b[31mERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.\n",
-            "jupyter-server 1.24.0 requires anyio<4,>=3.1.0, but you have anyio 4.8.0 which is incompatible.\u001b[0m\u001b[31m\n",
-            "\u001b[0m"
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m410.5/410.5 kB\u001b[0m \u001b[31m8.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m856.7/856.7 kB\u001b[0m \u001b[31m24.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25h  Building wheel for gofannon (pyproject.toml) ... \u001b[?25l\u001b[?25hdone\n"
           ]
         }
       ],
       "source": [
-        "!pip install openai==1.55.3 httpx==0.27.2 --force-reinstall git+https://github.com/The-AI-Alliance/gofannon.git@compositions --quiet"
+        "!pip install git+https://github.com/The-AI-Alliance/gofannon.git@main --quiet"
       ]
     },
     {
@@ -110,7 +95,7 @@
           "base_uri": "https://localhost:8080/"
         },
         "id": "Ixs27pNAyvZ9",
-        "outputId": "794cd218-b2d1-4bbb-a2ab-f8bceb031121"
+        "outputId": "c049aea0-bb80-453f-834f-e469ddb3a898"
       },
       "execution_count": 2,
       "outputs": [
@@ -118,53 +103,41 @@
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "2025-01-24 16:33:13,019 - gofannon.basic_math.exponents.Exponents - DEBUG - Initialized Exponents tool\n",
-            "2025-01-24 16:33:13,026 - gofannon.basic_math.multiplication.Multiplication - DEBUG - Initialized Multiplication tool\n",
-            "2025-01-24 16:33:13,028 - gofannon.basic_math.division.Division - DEBUG - Initialized Division tool\n",
-            "2025-01-24 16:33:13,029 - gofannon.basic_math.addition.Addition - DEBUG - Initialized Addition tool\n",
-            "2025-01-24 16:33:13,031 - gofannon.basic_math.subtraction.Subtraction - DEBUG - Initialized Subtraction tool\n",
-            "2025-01-24 16:33:13,040 - gofannon.reasoning.sequential_cot.SequentialCoT - DEBUG - Initialized SequentialCoT tool\n",
-            "2025-01-24 16:33:13,042 - gofannon.reasoning.hierarchical_cot.HierarchicalCoT - DEBUG - Initialized HierarchicalCoT tool\n",
-            "2025-01-24 16:33:13,054 - gofannon.reasoning.tree_of_thought.TreeOfThought - DEBUG - Initialized TreeOfThought tool\n"
+            "2025-03-25 06:24:13,788 - gofannon.basic_math.exponents.Exponents - DEBUG - Initialized Exponents tool\n",
+            "2025-03-25 06:24:13,789 - gofannon.basic_math.multiplication.Multiplication - DEBUG - Initialized Multiplication tool\n",
+            "2025-03-25 06:24:13,789 - gofannon.basic_math.division.Division - DEBUG - Initialized Division tool\n",
+            "2025-03-25 06:24:13,791 - gofannon.basic_math.addition.Addition - DEBUG - Initialized Addition tool\n",
+            "2025-03-25 06:24:13,792 - gofannon.basic_math.subtraction.Subtraction - DEBUG - Initialized Subtraction tool\n",
+            "2025-03-25 06:24:13,793 - gofannon.reasoning.sequential_cot.SequentialCoT - DEBUG - Initialized SequentialCoT tool\n"
           ]
         },
         {
           "output_type": "stream",
           "name": "stdout",
           "text": [
-            "Registered tools: [{'type': 'function', 'function': {'name': 'exponents', 'description': 'Calculate the result of a number raised to a power', 'parameters': {'type': 'object', 'properties': {'base': {'type': 'number', 'description': 'The base number'}, 'power': {'type': 'number', 'description': 'The power to which the base is raised'}}, 'required': ['base', 'power']}}}, {'type': 'function', 'function': {'name': 'multiplication', 'description': 'Calculate the product of two numbers', 'parameters': {'type': 'object', 'properties': {'num1': {'type': 'number', 'description': 'The first number'}, 'num2': {'type': 'number', 'description': 'The second number'}}, 'required': ['num1', 'num2']}}}, {'type': 'function', 'function': {'name': 'division', 'description': 'Calculate the quotient of two numbers', 'parameters': {'type': 'object', 'properties': {'num1': {'type': 'number', 'description': 'The dividend'}, 'num2': {'type': 'number', 'description': 'The divisor'}}, 'required': ['num1', 'num2']}}}, {'type': 'function', 'function': {'name': 'addition', 'description': 'Calculate the sum of two numbers', 'parameters': {'type': 'object', 'properties': {'num1': {'type': 'number', 'description': 'The first number'}, 'num2': {'type': 'number', 'description': 'The second number'}}, 'required': ['num1', 'num2']}}}, {'type': 'function', 'function': {'name': 'subtraction', 'description': 'Calculate the difference between two numbers', 'parameters': {'type': 'object', 'properties': {'num1': {'type': 'number', 'description': 'The minuend'}, 'num2': {'type': 'number', 'description': 'The subtrahend'}}, 'required': ['num1', 'num2']}}}, {'type': 'function', 'function': {'name': 'sequential_cot', 'description': 'Generate a series of steps required to solve a problem using Chain-of-Thought reasoning.', 'parameters': {'type': 'object', 'properties': {'prompt': {'type': 'string', 'description': 'The prompt to generate steps for.'}, 'steps': {'type': 'number', 'description': 'How many steps to take. (Default 3)'}}, 'required': ['prompt', 'steps']}}}, {'type': 'function', 'function': {'name': 'hierarchical_cot', 'description': 'Hierarchical Chain-of-Thought reasoning with outline generation and section expansion', 'parameters': {'type': 'object', 'properties': {'prompt': {'type': 'string', 'description': 'The problem prompt to process'}, 'depth': {'type': 'integer', 'description': 'Depth of hierarchy (default: 2)', 'default': 2}}, 'required': ['prompt']}}}, {'type': 'function', 'function': {'name': 'tree_of_thought', 'description': 'Tree-of-Thought reasoning with parallel exploration of multiple paths', 'parameters': {'type': 'object', 'properties': {'prompt': {'type': 'string', 'description': 'The problem prompt to process'}, 'branches': {'type': 'integer', 'description': 'Number of parallel branches (default: 3)', 'default': 3}, 'evaluation_depth': {'type': 'integer', 'description': 'Depth of evaluation steps (default: 2)', 'default': 2}}, 'required': ['prompt']}}}]\n"
+            "Registered tools: [{'type': 'function', 'function': {'name': 'exponents', 'description': 'Calculate the result of a number raised to a power', 'parameters': {'type': 'object', 'properties': {'base': {'type': 'number', 'description': 'The base number'}, 'power': {'type': 'number', 'description': 'The power to which the base is raised'}}, 'required': ['base', 'power']}}}, {'type': 'function', 'function': {'name': 'multiplication', 'description': 'Calculate the product of two numbers', 'parameters': {'type': 'object', 'properties': {'num1': {'type': 'number', 'description': 'The first number'}, 'num2': {'type': 'number', 'description': 'The second number'}}, 'required': ['num1', 'num2']}}}, {'type': 'function', 'function': {'name': 'division', 'description': 'Calculate the quotient of two numbers', 'parameters': {'type': 'object', 'properties': {'num1': {'type': 'number', 'description': 'The dividend'}, 'num2': {'type': 'number', 'description': 'The divisor'}}, 'required': ['num1', 'num2']}}}, {'type': 'function', 'function': {'name': 'addition', 'description': 'Calculate the sum of two numbers', 'parameters': {'type': 'object', 'properties': {'num1': {'type': 'number', 'description': 'The first number'}, 'num2': {'type': 'number', 'description': 'The second number'}}, 'required': ['num1', 'num2']}}}, {'type': 'function', 'function': {'name': 'subtraction', 'description': 'Calculate the difference between two numbers', 'parameters': {'type': 'object', 'properties': {'num1': {'type': 'number', 'description': 'The minuend'}, 'num2': {'type': 'number', 'description': 'The subtrahend'}}, 'required': ['num1', 'num2']}}}, {'type': 'function', 'function': {'name': 'sequential_cot', 'description': 'Generate a series of steps required to solve a problem using Chain-of-Thought reasoning.', 'parameters': {'type': 'object', 'properties': {'prompt': {'type': 'string', 'description': 'The prompt to generate steps for.'}, 'steps': {'type': 'number', 'description': 'How many steps to take. (Default 3)'}}, 'required': ['prompt', 'steps']}}}]\n"
           ]
         },
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "2025-01-24 16:33:13,678 - gofannon.basic_math.exponents.Exponents - DEBUG - Initialized Exponents tool\n",
-            "2025-01-24 16:33:13,689 - gofannon.basic_math.multiplication.Multiplication - DEBUG - Initialized Multiplication tool\n",
-            "2025-01-24 16:33:13,694 - gofannon.basic_math.division.Division - DEBUG - Initialized Division tool\n",
-            "2025-01-24 16:33:13,696 - gofannon.basic_math.addition.Addition - DEBUG - Initialized Addition tool\n",
-            "2025-01-24 16:33:13,698 - gofannon.basic_math.subtraction.Subtraction - DEBUG - Initialized Subtraction tool\n",
-            "2025-01-24 16:33:13,700 - gofannon.reasoning.sequential_cot.SequentialCoT - DEBUG - Initialized SequentialCoT tool\n",
-            "2025-01-24 16:33:13,707 - gofannon.reasoning.hierarchical_cot.HierarchicalCoT - DEBUG - Initialized HierarchicalCoT tool\n",
-            "2025-01-24 16:33:13,712 - gofannon.reasoning.tree_of_thought.TreeOfThought - DEBUG - Initialized TreeOfThought tool\n",
-            "2025-01-24 16:33:13,723 - gofannon.orchestration.FunctionOrchestrator - DEBUG - Available functions in orchestrator: exponents, multiplication, division, addition, subtraction, sequential_cot, hierarchical_cot, tree_of_thought\n",
-            "2025-01-24 16:33:13,726 - gofannon.orchestration.FunctionOrchestrator - DEBUG - Starting workflow execution with query: Calculate ((2^3 * 5) + 10) / (4 - 1) using step-by-step function calls.\n",
-            "2025-01-24 16:33:16,222 - gofannon.basic_math.exponents.Exponents - DEBUG - Initialized Exponents tool\n",
-            "2025-01-24 16:33:16,224 - gofannon.basic_math.exponents - DEBUG - Raising 2.0 to the 3.0th power\n",
-            "2025-01-24 16:33:16,231 - gofannon.basic_math.exponents.Exponents - DEBUG - Initialized Exponents tool\n",
-            "2025-01-24 16:33:16,241 - gofannon.basic_math.exponents - DEBUG - Raising 5.0 to the 1.0th power\n",
-            "2025-01-24 16:33:16,249 - gofannon.basic_math.exponents.Exponents - DEBUG - Initialized Exponents tool\n",
-            "2025-01-24 16:33:16,250 - gofannon.basic_math.exponents - DEBUG - Raising 2.0 to the 1.0th power\n",
-            "2025-01-24 16:33:16,252 - gofannon.basic_math.multiplication.Multiplication - DEBUG - Initialized Multiplication tool\n",
-            "2025-01-24 16:33:16,266 - gofannon.basic_math.multiplication - DEBUG - Multiplying 8.0 by 5.0\n",
-            "2025-01-24 16:33:16,267 - gofannon.basic_math.addition.Addition - DEBUG - Initialized Addition tool\n",
-            "2025-01-24 16:33:16,268 - gofannon.basic_math.addition - DEBUG - Adding 40.0 and 10.0\n",
-            "2025-01-24 16:33:16,276 - gofannon.basic_math.exponents.Exponents - DEBUG - Initialized Exponents tool\n",
-            "2025-01-24 16:33:16,277 - gofannon.basic_math.exponents - DEBUG - Raising 4.0 to the 1.0th power\n",
-            "2025-01-24 16:33:16,282 - gofannon.basic_math.subtraction.Subtraction - DEBUG - Initialized Subtraction tool\n",
-            "2025-01-24 16:33:16,283 - gofannon.basic_math.subtraction - DEBUG - Subtracting 1.0 from 4.0\n",
-            "2025-01-24 16:33:16,291 - gofannon.basic_math.division.Division - DEBUG - Initialized Division tool\n",
-            "2025-01-24 16:33:16,292 - gofannon.basic_math.division - DEBUG - Dividing 50.0 by 3.0\n"
+            "2025-03-25 06:24:14,511 - gofannon.basic_math.exponents.Exponents - DEBUG - Initialized Exponents tool\n",
+            "2025-03-25 06:24:14,512 - gofannon.basic_math.multiplication.Multiplication - DEBUG - Initialized Multiplication tool\n",
+            "2025-03-25 06:24:14,513 - gofannon.basic_math.division.Division - DEBUG - Initialized Division tool\n",
+            "2025-03-25 06:24:14,514 - gofannon.basic_math.addition.Addition - DEBUG - Initialized Addition tool\n",
+            "2025-03-25 06:24:14,515 - gofannon.basic_math.subtraction.Subtraction - DEBUG - Initialized Subtraction tool\n",
+            "2025-03-25 06:24:14,516 - gofannon.reasoning.sequential_cot.SequentialCoT - DEBUG - Initialized SequentialCoT tool\n",
+            "2025-03-25 06:24:14,517 - gofannon.orchestration.FunctionOrchestrator - DEBUG - Available functions in orchestrator: exponents, multiplication, division, addition, subtraction, sequential_cot\n",
+            "2025-03-25 06:24:14,518 - gofannon.orchestration.FunctionOrchestrator - DEBUG - Starting workflow execution with query: Calculate ((2^3 * 5) + 10) / (4 - 1) using step-by-step function calls.\n",
+            "2025-03-25 06:24:16,973 - gofannon.basic_math.exponents.Exponents - DEBUG - Initialized Exponents tool\n",
+            "2025-03-25 06:24:16,974 - gofannon.basic_math.exponents - DEBUG - Raising 2.0 to the 3.0th power\n",
+            "2025-03-25 06:24:16,975 - gofannon.basic_math.multiplication.Multiplication - DEBUG - Initialized Multiplication tool\n",
+            "2025-03-25 06:24:16,976 - gofannon.basic_math.multiplication - DEBUG - Multiplying 5.0 by 8.0\n",
+            "2025-03-25 06:24:16,977 - gofannon.basic_math.addition.Addition - DEBUG - Initialized Addition tool\n",
+            "2025-03-25 06:24:16,978 - gofannon.basic_math.addition - DEBUG - Adding 10.0 and 40.0\n",
+            "2025-03-25 06:24:16,978 - gofannon.basic_math.division.Division - DEBUG - Initialized Division tool\n",
+            "2025-03-25 06:24:16,979 - gofannon.basic_math.division - DEBUG - Dividing 50.0 by 3.0\n"
           ]
         }
       ]
@@ -179,7 +152,7 @@
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "785e2fc3-139b-45de-c439-7c4ecf6b6a00"
+        "outputId": "dab87d9b-8579-4e0b-fbd6-4b34e5159b64"
       },
       "execution_count": 4,
       "outputs": [
@@ -187,7 +160,13 @@
           "output_type": "stream",
           "name": "stdout",
           "text": [
-            "Therefore, ((2^3 * 5) + 10) / (4 - 1) is equal to 16.67.\n"
+            "This calculation is correct because:\n",
+            "\n",
+            "1. 2^3 = 8\n",
+            "2. 8 * 5 = 40\n",
+            "3. 40 + 10 = 50\n",
+            "4. 4 - 1 = 3\n",
+            "5. 50 / 3 = 16.666666666666668\n"
           ]
         }
       ]


### PR DESCRIPTION
# PR Template: New Function or Feature

## Description of Changes
In the file `examples/Complex_Math.ipynb`

[this line](https://github.com/The-AI-Alliance/gofannon/blob/main/examples/Complex_Math.ipynb?short_path=d628b77#L43) points to a branch `compositions` which is an artifact of it's previous home. The line also has a work around for when httpx and openai had a bug.

## Related Issues
List any related issues or PRs that this submission addresses:

* Closes #18 

## Testing Performed
Describe the testing performed to validate the changes:

Ran `examples/Complex_Math.ipynb` 

## Code Changes
Provide an overview of the code changes made:
Changed:
```
!pip install openai==1.55.3 httpx==0.27.2 --force-reinstall git+https://github.com/The-AI-Alliance/gofannon.git@compositions --quiet
```
to 
```
!pip install git+https://github.com/The-AI-Alliance/gofannon.git@main --quiet
```

## Example Usage
Include an example of how to use the new function or feature:

* Run `examples/Complex_Math.ipynb` to test complex math

## Checklist
Confirm that the following have been completed:

* [ ] All new functions have been documented in the `docs/` directory
* [ ] New functions have been added to the `ROADMAP.md` file
* [ ] Unit tests have been added for new functions
* [x] Code follows the existing style and convention
* [x] API keys or sensitive information have been removed

## Additional Context
Any additional context or information that might be helpful for reviewers:

* Do we need to fix the work around for when httpx and openai had a bug for other example files as well?
