### PR TITLE
add hype video to landing page

### DIFF
--- a/website/index.md
+++ b/website/index.md
@@ -9,6 +9,8 @@ title: Home
         <p class="lead">Forging next-generation AI capabilities</p>  
         <a href="{{ '/docs' | relative_url }}" class="btn btn-light btn-lg">Get Started</a>  
     </div>  
+    <p></p>
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/q0c3CcDdPaU?si=Xwyt8-MP0VtjCu23" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 </div>  
 
 <div class="container my-5">  


### PR DESCRIPTION
Click the `Preview` tab and select a PR template:

- [Docs/Website Only change](?expand=1&template=docs_website_pr.md)
- [Other change](?expand=1&template=general_code_pr.md)

[//]: # (Dumb that we have to do this hack, see https://github.com/orgs/community/discussions/4620 for progress on github fixing this)