### PR TITLE
Add redirect for website/how-tos/contribute-tool.md

### DIFF
--- a/website/Gemfile
+++ b/website/Gemfile
@@ -17,6 +17,7 @@ gem "minima", "~> 2.5"
 group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.12"
   gem "jekyll-sitemap"
+  gem "jekyll-redirect-from"
 end
 
 # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/website/_config.yml
+++ b/website/_config.yml
@@ -8,6 +8,8 @@ google_tag_id:  G-S4YL0CG31S
 discord_link: https://discord.gg/2MMCVs76Sr
 plugins:
   - jekyll-sitemap
+  - jekyll-redirect-from
+
 
 collections:
   docs:

--- a/website/developers/contribute_tool.md
+++ b/website/developers/contribute_tool.md
@@ -1,6 +1,8 @@
 ---  
 layout: default  
 title: Contributing A Tool
+redirect_from:
+  - /how-tos/contribute_tool.html
 ---  
 
 # Tutorial: Contributing a New Tool to Gofannon


### PR DESCRIPTION
# PR Template: Documentation/Website Change

## Description of Changes
- Updated _config.yml and Gemfile for proper redirects
- Updated contribute_tool.md to redirect from [QR link](https://the-ai-alliance.github.io/gofannon/how-tos/contribute_tool.html)

## Related Issues
* Closes #266 

## Testing Performed
- A [known issue](https://github.com/jekyll/jekyll/issues/9741) exists between `jekyll ~> 4.3.4` and Ruby 3.4.1, which affected my local environment.
- Tested using **Jekyll 4.4**.
- Verified that navigating to `/how-tos/contribute_tool.html` redirects as expected to `/developers/contribute_tool.html` using:
 ```bash
  bundle exec jekyll serve
```
## Code Changes
List all files modified/added:
* website/_config.yml
* website/Gemfile
* website/developers/contribute_tool.md

## Preview
Provide a link to a preview of the changes (if applicable) or describe how to view them locally.

## Checklist
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide
- [ ] My changes follow the documentation style guide
- [ ] I have updated any related documentation
- [ ] I have added/updated tests if applicable
- [ ] I have included necessary screenshots or examples

## Additional Context
I’ll open a separate issue to highlight the compatibility issue with `jekyll ~> 4.3.4` on newer Ruby versions, as suggested.
I’ll assign it to myself and submit a follow-up PR to update Jekyll to `~> 4.4` as a fix.