### PR TITLE
vibe fix to adk bug

### DIFF
--- a/gofannon/base/adk_mixin.py
+++ b/gofannon/base/adk_mixin.py
@@ -3,6 +3,7 @@
 import inspect
 import json
 from typing import Any, Callable, Dict, List, Optional, Type as TypingType
+import functools # Add this import
 
 # Try to import ADK components
 try:
@@ -51,7 +52,7 @@ except ImportError:
                 self.parameters = parameters
 
 
-            # Helper for ADK Schema to Gofannon JSON Schema
+                # Helper for ADK Schema to Gofannon JSON Schema
 ADK_GEMINI_TYPE_TO_JSON_TYPE = {
     adk_gemini_types.Type.STRING: "string",
     adk_gemini_types.Type.INTEGER: "integer",
@@ -279,7 +280,9 @@ class AdkMixin:
                 else:
                     # Gofannon's synchronous fn needs to be run in a thread
                     # as ADK's run_async is an async method.
-                    return await anyio.to_thread.run_sync(self._gofannon_exec_fn, **args) # type: ignore
+                    # Use functools.partial to create a callable with arguments pre-bound.
+                    func_with_bound_args = functools.partial(self._gofannon_exec_fn, **args)
+                    return await anyio.to_thread.run_sync(func_with_bound_args)
 
         exported_adk_tool = GofannonAdkTool(
             name=tool_name,


### PR DESCRIPTION
# PR Template: New Function or Feature  
  
## Description of Changes  
Please provide a brief description of the changes made in this pull request:  
  
* **What is the purpose of this PR?**  
  This PR fixes a `TypeError` that occurred when exporting Gofannon tools with parameters (expecting keyword arguments) to the Google ADK format. Specifically, synchronous Gofannon tool functions were not correctly receiving their arguments when invoked by the ADK's asynchronous `run_async` method.  
  
* **What new function or feature is being added?**  
  This is primarily a bug fix. The improvement is to the `export_to_adk` method within the `AdkMixin` class, ensuring that synchronous Gofannon tool functions are correctly called with their keyword arguments when integrated with the ADK.  
  
* **How does it improve the existing repository?**  
  It makes the `export_to_adk` functionality more robust and allows Gofannon tools that require parameters (like the `WikipediaLookup` tool) to work seamlessly with the Google ADK framework. Previously, such tools would fail during execution due to an argument passing mismatch.  
  
## Related Issues  
None- I was too lazy to report the bug, i just found and bashed. 

## Testing Performed  
Describe the testing performed to validate the changes:  
  
* The fix was tested by the user with a `WikipediaLookup` tool, which requires a `query` parameter. After applying the change, the tool executed successfully within the Google ADK `AdkApp` environment, resolving the `TypeError`.  
* Tested with Gofannon tools that do not require parameters (e.g., `iss_locator`) to ensure no regressions.  
  
## Code Changes  
Provide an overview of the code changes made:  
  
* **Modified files or functions:**  
    * `gofannon/base/adk_mixin.py`:  
        * Added `import functools`.  
        * Modified the `run_async` method within the nested `GofannonAdkTool` class. Specifically, the `else` block (for handling synchronous Gofannon functions) was updated to use `functools.partial` to correctly bind keyword arguments before calling `anyio.to_thread.run_sync`.  
            *   Changed:  
                `return await anyio.to_thread.run_sync(self._gofannon_exec_fn, **args)`  
            *   To:  
                `func_with_bound_args = functools.partial(self._gofannon_exec_fn, **args)`  
                `return await anyio.to_thread.run_sync(func_with_bound_args)`  
  
## Example Usage  
Include an example of how to use the new function or feature:  
  
* The example usage provided in the original problem description now works correctly with this fix:  
  
$$$python  
import vertexai  
from gofannon.wikipedia.wikipedia_lookup import WikipediaLookup  
from google.adk.agents import Agent  
from vertexai.preview import reasoning_engines  
  
PROJECT_ID = "agent-coe-text" # Replace with your Project ID  
LOCATION = "us-central1"  
STAGING_BUCKET = f"gs://{PROJECT_ID}-storage-bucket"  
  
vertexai.init(  
    project=PROJECT_ID,  
    location=LOCATION,  
    staging_bucket=STAGING_BUCKET,  
)  
MODEL="gemini-1.5-flash-001" # Or your preferred model  
INSTRUCTION= "You are a helpful agent who can answer user questions augmented with knowledge from Wikipedia"  
MESSAGE = "What is the capital of France?"  
  
# Gofannon tool exported to ADK  
gofannon_tool_instance = WikipediaLookup()  
exported_adk_tool = gofannon_tool_instance.export_to_adk()  
  
root_agent = Agent(  
    name="wiki_query_agent",  
    model=MODEL,  
    description=(  
        "Agent to answer questions using Wikipedia."  
    ),  
    instruction=(  
       INSTRUCTION  
    ),  
    tools=[exported_adk_tool], # Use the exported ADK tool  
)  
  
app = reasoning_engines.AdkApp(  
    agent=root_agent,  
    enable_tracing=True,  
)  
session = app.create_session(user_id="user_test_123") # Example user_id  
for event in app.stream_query(  
    user_id="user_test_123", # Example user_id  
    session_id=session.id,  
    message=MESSAGE,  
):  
  print(event)  
$$$  
  
* **Expected output or results:**  
  The ADK agent will now successfully call the `wikipedia_lookup` tool with the `query` argument, and the tool will execute, returning the Wikipedia summary for "capital of France". The `TypeError` will no longer occur.  
  
## Checklist  
Confirm that the following have been completed:  
  
* [ ] All new functions have been documented in the `docs/` directory (N/A - Bug fix)  
* [ ] Unit tests have been added for new functions (Considered: Existing tests for ADK export should cover this once the fix is in. If specific tests for argument passing in this scenario are missing, they could be added.)  
* [X] Code follows the existing style and convention  
* [X] API keys or sensitive information have been removed  
  
## Additional Context  
Any additional context or information that might be helpful for reviewers:  
  
* The root cause was the `anyio.to_thread.run_sync` function's API, which expects the callable's arguments to be passed positionally *after* the callable itself, not as keyword arguments to `run_sync`. `functools.partial` is a standard way to pre-bind arguments (including keyword arguments) to a function, creating a new callable that `run_sync` can then execute.  
* The OpenTelemetry/asyncio cancellation errors mentioned in the original problem description might be unrelated or secondary issues, but this PR directly resolves the `TypeError`.  