### PR TITLE
Add button for setting what model will compose agent

### DIFF
--- a/webapp/packages/webui/src/components/ModelConfigDialog.jsx
+++ b/webapp/packages/webui/src/components/ModelConfigDialog.jsx
@@ -1,0 +1,209 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  Slider,
+  Typography,
+  Box,
+  Divider,
+  TextField,
+  CircularProgress,
+  Alert,
+} from '@mui/material';
+
+const ModelConfigDialog = ({
+  open,
+  onClose,
+  title,
+  providers,
+  selectedProvider,
+  setSelectedProvider,
+  selectedModel,
+  setSelectedModel,
+  modelParamSchema,
+  setModelParamSchema,
+  currentModelParams,
+  setCurrentModelParams,
+  loadingProviders,
+  providersError,
+}) => {
+
+  const handleProviderChange = (e) => {
+    const provider = e.target.value;
+    setSelectedProvider(provider);
+    
+    const models = Object.keys(providers[provider]?.models || {});
+    if (models.length > 0) {
+      const defaultModel = models[0];
+      setSelectedModel(defaultModel);
+      const modelParams = providers[provider].models[defaultModel].parameters; 
+      setModelParamSchema(modelParams);
+      
+      const defaultParams = {};
+      Object.keys(modelParams).forEach(key => {
+        defaultParams[key] = modelParams[key].default;
+      });
+      setCurrentModelParams(defaultParams);
+    } else {
+      setSelectedModel('');
+      setModelParamSchema({});
+      setCurrentModelParams({});
+    }
+  };
+
+  const handleModelChange = (e) => {
+    const model = e.target.value;
+    setSelectedModel(model);
+    
+    const modelParams = providers[selectedProvider].models[model].parameters; 
+    setModelParamSchema(modelParams);
+    
+    const defaultParams = {};
+    Object.keys(modelParams).forEach(key => {
+      defaultParams[key] = modelParams[key].default;
+    });
+    setCurrentModelParams(defaultParams);
+  };
+
+  const handleParamChange = (paramName, value) => {
+    setCurrentModelParams(prev => ({
+      ...prev,
+      [paramName]: value,
+    }));
+  };
+
+  const renderParamControl = (paramName, paramConfig) => {
+    const value = currentModelParams[paramName];
+    const controlledValue = value !== undefined ? value : paramConfig.default;
+
+    if (paramConfig.type === 'float' || paramConfig.type === 'integer') {
+      return (
+        <Box key={paramName} sx={{ mb: 2 }}>
+          <Typography gutterBottom variant="body2" color="text.secondary">
+            {paramConfig.description || paramName}: <Typography component="span" variant="body1" color="text.primary">{controlledValue}</Typography>
+          </Typography>
+          <Slider
+            value={controlledValue}
+            onChange={(e, newValue) => handleParamChange(paramName, newValue)}
+            min={paramConfig.min}
+            max={paramConfig.max}
+            step={paramConfig.type === 'float' ? (paramConfig.step || 0.1) : 1} 
+            marks
+            valueLabelDisplay="auto"
+          />
+        </Box>
+      );
+    }
+
+    return (
+      <TextField
+        key={paramName}
+        fullWidth
+        label={paramConfig.description || paramName}
+        value={controlledValue}
+        onChange={(e) => handleParamChange(paramName, e.target.value)}
+        sx={{ mb: 2 }}
+        type={paramConfig.type === 'integer' ? 'number' : 'text'}
+      />
+    );
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>{title}</DialogTitle>
+      <DialogContent>
+        {loadingProviders && (
+          <Box sx={{ display: 'flex', justifyContent: 'center', my: 2 }}>
+            <CircularProgress />
+          </Box>
+        )}
+        {providersError && (
+          <Alert severity="error" sx={{ my: 2 }}>
+            {providersError}
+          </Alert>
+        )}
+        {!loadingProviders && !providersError && Object.keys(providers).length === 0 && (
+          <Alert severity="warning" sx={{ my: 2 }}>
+            No AI providers found. Please check your backend configuration.
+          </Alert>
+        )}
+
+        {!loadingProviders && !providersError && Object.keys(providers).length > 0 && (
+          <>
+            <FormControl fullWidth sx={{ mb: 2, mt: 1 }}>
+              <InputLabel>Provider</InputLabel>
+              <Select
+                value={selectedProvider}
+                onChange={handleProviderChange}
+                label="Provider"
+              >
+                {Object.keys(providers).map(provider => (
+                  <MenuItem key={provider} value={provider}>{provider}</MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+
+            {selectedProvider && (
+              <FormControl fullWidth sx={{ mb: 3 }}>
+                <InputLabel>Model</InputLabel>
+                <Select
+                  value={selectedModel}
+                  onChange={handleModelChange}
+                  label="Model"
+                >
+                  {Object.keys(providers[selectedProvider]?.models || {}).map(model => (
+                    <MenuItem key={model} value={model}>{model}</MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            )}
+
+            <Divider sx={{ my: 2 }} />
+            
+            <Typography variant="h6" gutterBottom>
+              Model Parameters
+            </Typography>
+            
+            {selectedModel && Object.keys(modelParamSchema).map(paramName => 
+              renderParamControl(paramName, modelParamSchema[paramName])
+            )}
+          </>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Close</Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+ModelConfigDialog.propTypes = {
+  open: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  title: PropTypes.string.isRequired,
+  providers: PropTypes.object.isRequired,
+  selectedProvider: PropTypes.string.isRequired,
+  setSelectedProvider: PropTypes.func.isRequired,
+  selectedModel: PropTypes.string.isRequired,
+  setSelectedModel: PropTypes.func.isRequired,
+  modelParamSchema: PropTypes.object.isRequired,
+  setModelParamSchema: PropTypes.func.isRequired,
+  currentModelParams: PropTypes.object.isRequired,
+  setCurrentModelParams: PropTypes.func.isRequired,
+  loadingProviders: PropTypes.bool.isRequired,
+  providersError: PropTypes.string,
+};
+
+ModelConfigDialog.defaultProps = {
+  providersError: null,
+};
+
+export default ModelConfigDialog;

--- a/webapp/packages/webui/src/pages/AgentCreationFlow/SchemasScreen.jsx
+++ b/webapp/packages/webui/src/pages/AgentCreationFlow/SchemasScreen.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
   Box,
@@ -7,19 +7,79 @@ import {
   Paper,
   Grid,
   Divider,
+  Alert,
+  Chip,
+  CircularProgress
 } from '@mui/material';
 import CodeIcon from '@mui/icons-material/Code';
 import EditIcon from '@mui/icons-material/Edit';
+import SettingsIcon from '@mui/icons-material/Settings'; // Import SettingsIcon
 import { useAgentFlow } from './AgentCreationFlowContext';
+import chatService from '../../services/chatService'; // Re-use chatService to fetch providers
+import ModelConfigDialog from '../../components/ModelConfigDialog'; // Import the new component
 
 const SchemasScreen = () => {
   const { tools, description, inputSchema, outputSchema, setGeneratedCode } = useAgentFlow();
   const navigate = useNavigate();
 
-  const mockBackendCallAndGenerateCode = () => {
-    // This function simulates the backend call to generate code.
-    // In a real scenario, you'd make an API request with `tools`, `description`, `inputSchema`, `outputSchema`.
-    // For now, we set a mock "hello world" Python code.
+  // State for Model Configuration
+  const [modelConfigDialogOpen, setModelConfigDialogOpen] = useState(false);
+  const [providers, setProviders] = useState({});
+  const [selectedProvider, setSelectedProvider] = useState('');
+  const [selectedModel, setSelectedModel] = useState('');
+  const [modelParamSchema, setModelParamSchema] = useState({});
+  const [currentModelParams, setCurrentModelParams] = useState({});
+  const [loadingProviders, setLoadingProviders] = useState(true);
+  const [providersError, setProvidersError] = useState(null);
+
+  // Fetch providers on component mount
+  useEffect(() => {
+    const fetchProviders = async () => {
+      setLoadingProviders(true);
+      setProvidersError(null);
+      try {
+        const providersData = await chatService.getProviders();
+        setProviders(providersData);
+  
+        const providerKeys = Object.keys(providersData);
+        if (providerKeys.length > 0) {
+          const defaultProvider = providerKeys[0];
+          setSelectedProvider(defaultProvider);
+  
+          const models = Object.keys(providersData[defaultProvider].models);
+          if (models.length > 0) {
+            const defaultModel = models[0];
+            setSelectedModel(defaultModel);
+            const modelParams = providersData[defaultProvider].models[defaultModel].parameters;
+            setModelParamSchema(modelParams);
+  
+            const defaultParams = {};
+            Object.keys(modelParams).forEach(key => {
+              defaultParams[key] = modelParams[key].default;
+            });
+            setCurrentModelParams(defaultParams);
+          } else {
+            setSelectedModel('');
+            setModelParamSchema({});
+            setCurrentModelParams({});
+          }
+        } else {
+          setProvidersError('No AI providers found.');
+        }
+      } catch (err) {
+        setProvidersError('Failed to fetch AI providers: ' + err.message);
+        console.error("Error fetching providers for agent creation:", err);
+      } finally {
+        setLoadingProviders(false);
+      }
+    };
+    fetchProviders();
+  }, []);
+
+  const mockBackendCallAndGenerateCode = (agentModelConfig) => {
+    // Extract model configuration for the generated code
+    const { provider, model, parameters } = agentModelConfig;
+
     const mockPythonCode = `
 import json
 
@@ -31,20 +91,23 @@ def agent_handler(input_data):
     Agent Description: ${description || "No description provided."}
 
     Tools: ${
-      Object.entries(tools) // Iterate over [url, selectedToolsArray] pairs
-        .filter(([, selectedTools]) => selectedTools.length > 0) // Only include URLs with selected tools
+      Object.entries(tools)
+        .filter(([, selectedTools]) => selectedTools.length > 0)
         .map(([url, selectedTools]) => 
-          `${url} (using: ${selectedTools.join(', ')})` // Format as "url (using: tool1, tool2)"
+          `${url} (using: ${selectedTools.join(', ')})`
         )
-        .join('\n      ') // Join multiple MCP server entries with a newline and indentation
+        .join('\n      ')
       || "No tools defined."
     }
 
-    Input Schema:
-    ${JSON.stringify(inputSchema, null, 2)}
+    Input Schema:\n    ${JSON.stringify(inputSchema, null, 2)}
 
-    Output Schema:
-    ${JSON.stringify(outputSchema, null, 2)}
+    Output Schema:\n    ${JSON.stringify(outputSchema, null, 2)}
+
+    Model for Code Generation:
+      Provider: ${provider || 'N/A'}
+      Model: ${model || 'N/A'}
+      Parameters: ${JSON.stringify(parameters, null, 2)}
     """
     
     # Parse the input JSON
@@ -68,9 +131,19 @@ if __name__ == "__main__":
   };
 
   const handleBuild = () => {
-    mockBackendCallAndGenerateCode();
+    if (!selectedProvider || !selectedModel) {
+      setProvidersError('Please select a model for code generation.');
+      return;
+    }
+    mockBackendCallAndGenerateCode({
+      provider: selectedProvider,
+      model: selectedModel,
+      parameters: currentModelParams,
+    });
     navigate('/create-agent/code');
   };
+
+  const isModelSelected = selectedProvider && selectedModel;
 
   return (
     <Paper sx={{ p: 3, maxWidth: 800, margin: 'auto', mt: 4 }}>
@@ -82,11 +155,17 @@ if __name__ == "__main__":
         optionally define more complex JSON structures here. (Edit disabled for POC)
       </Typography>
 
+      {providersError && (
+        <Alert severity="error" sx={{ mb: 2 }} onClose={() => setProvidersError(null)}>
+          {providersError}
+        </Alert>
+      )}
+
       <Grid container spacing={3} sx={{ mb: 3 }}>
         <Grid item xs={12} md={6}>
           <Box sx={{ border: '1px solid #ddd', borderRadius: 1, p: 2, bgcolor: 'background.default' }}>
             <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
-              <Typography variant="h6">Input JSON Schema</Typography>
+              <Typography variant="h6\">Input JSON Schema</Typography>
               <Button size="small" startIcon={<EditIcon />} disabled>Edit</Button>
             </Box>
             <Box sx={{ bgcolor: 'grey.900', p: 1, borderRadius: 1, overflowX: 'auto' }}>
@@ -99,7 +178,7 @@ if __name__ == "__main__":
         <Grid item xs={12} md={6}>
           <Box sx={{ border: '1px solid #ddd', borderRadius: 1, p: 2, bgcolor: 'background.default' }}>
             <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
-              <Typography variant="h6">Output JSON Schema</Typography>
+              <Typography variant="h6\">Output JSON Schema</Typography>
               <Button size="small" startIcon={<EditIcon />} disabled>Edit</Button>
             </Box>
             <Box sx={{ bgcolor: 'grey.900', p: 1, borderRadius: 1, overflowX: 'auto' }}>
@@ -113,15 +192,58 @@ if __name__ == "__main__":
 
       <Divider sx={{ my: 3 }} />
 
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 3 }}>
+        <Typography variant="h6">Model for Code Generation</Typography>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          {loadingProviders ? (
+            <CircularProgress size={20} />
+          ) : isModelSelected ? (
+            <Chip 
+              label={`${selectedProvider}/${selectedModel}`}
+              color="secondary" 
+              variant="outlined"
+            />
+          ) : (
+            <Typography color="text.secondary">No model selected</Typography>
+          )}
+          <Button
+            variant="outlined"
+            startIcon={<SettingsIcon />}
+            onClick={() => setModelConfigDialogOpen(true)}
+            disabled={loadingProviders || providersError}
+          >
+            {isModelSelected ? 'Change Model' : 'Choose Model'}
+          </Button>
+        </Box>
+      </Box>
+
       <Button
         variant="contained"
         color="primary"
         onClick={handleBuild}
         fullWidth
         startIcon={<CodeIcon />}
+        disabled={!isModelSelected}
       >
         Build Agent Code
       </Button>
+
+      <ModelConfigDialog
+        open={modelConfigDialogOpen}
+        onClose={() => setModelConfigDialogOpen(false)}
+        title="Configure Agent Code Generation Model"
+        providers={providers}
+        selectedProvider={selectedProvider}
+        setSelectedProvider={setSelectedProvider}
+        selectedModel={selectedModel}
+        setSelectedModel={setSelectedModel}
+        modelParamSchema={modelParamSchema}
+        setModelParamSchema={setModelParamSchema}
+        currentModelParams={currentModelParams}
+        setCurrentModelParams={setCurrentModelParams}
+        loadingProviders={loadingProviders}
+        providersError={providersError}
+      />
     </Paper>
   );
 };


### PR DESCRIPTION
Closes #345

Refactored Model config to its own component (used to live in chat page). Added a button to bring it up to set the model that will be used to compose the agent. Confrims it still works in the chat window

<img width="848" height="500" alt="image" src="https://github.com/user-attachments/assets/9e7decdd-7aca-4095-a907-13057ed8c91e" />
