### PR TITLE
Handle saved agents better

### DIFF
--- a/webapp/packages/webui/src/App.jsx
+++ b/webapp/packages/webui/src/App.jsx
@@ -2,15 +2,16 @@ import React, { useContext, useEffect } from 'react';
 import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
 import config from './config';
 import { AuthContext } from './contexts/AuthContext';
-import { AgentCreationFlowProvider } from './pages/AgentCreationFlow/AgentCreationFlowContext'; // Import AgentCreationFlowProvider
+import { AgentCreationFlowProvider } from './pages/AgentCreationFlow/AgentCreationFlowContext'; 
 import Layout from './components/Layout';
 import LoginPage from './pages/LoginPage';
 import HomePage from './pages/HomePage';
 import ChatPage from './pages/ChatPage';
-import ToolsScreen from './pages/AgentCreationFlow/ToolsScreen'; // Import agent flow screens
+import ViewAgent from './pages/ViewAgent';
+import SavedAgentsPage from './pages/SavedAgentsPage';
+import ToolsScreen from './pages/AgentCreationFlow/ToolsScreen'; 
 import DescriptionScreen from './pages/AgentCreationFlow/DescriptionScreen';
 import SchemasScreen from './pages/AgentCreationFlow/SchemasScreen';
-import CodeEditorScreen from './pages/AgentCreationFlow/CodeEditorScreen';
 import SandboxScreen from './pages/AgentCreationFlow/SandboxScreen';
 import DeployScreen from './pages/AgentCreationFlow/DeployScreen';
 import SaveAgentScreen from './pages/AgentCreationFlow/SaveAgentScreen';
@@ -48,6 +49,16 @@ function App() {
           }
         />
         <Route
+          path="/agents"
+          element={
+            <PrivateRoute>
+              <Layout>
+                <SavedAgentsPage />
+              </Layout>
+            </PrivateRoute>
+          }
+        />
+        <Route
           path="/chat"
           element={
             <PrivateRoute>
@@ -57,7 +68,19 @@ function App() {
             </PrivateRoute>
           }
         />
-        {/* Agent Creation Flow Routes */}
+        <Route
+          path="/agent/:agentId"
+          element={
+            <PrivateRoute>
+              <Layout>
+                {/* Provider is needed for navigation to sandbox/deploy */}
+                <AgentCreationFlowProvider>
+                  <ViewAgent />
+                </AgentCreationFlowProvider>
+              </Layout>
+            </PrivateRoute>
+          }
+        />
         <Route 
           path="/create-agent/*" 
           element={
@@ -69,7 +92,7 @@ function App() {
                     <Route path="tools" element={<ToolsScreen />} />
                     <Route path="description" element={<DescriptionScreen />} />
                     <Route path="schemas" element={<SchemasScreen />} />
-                    <Route path="code" element={<CodeEditorScreen />} />
+                    <Route path="code" element={<ViewAgent isCreating={true} />} />
                     <Route path="sandbox" element={<SandboxScreen />} />
                     <Route path="deploy" element={<DeployScreen />} />
                     <Route path="save" element={<SaveAgentScreen />} />

--- a/webapp/packages/webui/src/components/CodeEditor.jsx
+++ b/webapp/packages/webui/src/components/CodeEditor.jsx
@@ -1,0 +1,54 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { Box, Typography, Button, TextField } from '@mui/material';
+import EditIcon from '@mui/icons-material/Edit';
+import SaveIcon from '@mui/icons-material/Save';
+
+const CodeEditor = ({ code, onCodeChange, isReadOnly = false }) => {
+  const [isEditing, setIsEditing] = useState(!isReadOnly);
+
+  const handleToggleEdit = () => {
+    setIsEditing(prev => !prev);
+  };
+
+  const effectiveReadOnly = isReadOnly && !isEditing;
+
+  return (
+    <Box sx={{ border: '1px solid #ddd', borderRadius: 1, p: 2, bgcolor: 'background.default' }}>
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
+        <Typography variant="h6">Python Code</Typography>
+        {isReadOnly && (
+          <Button size="small" startIcon={isEditing ? <SaveIcon /> : <EditIcon />} onClick={handleToggleEdit}>
+            {isEditing ? 'Lock' : 'Edit'}
+          </Button>
+        )}
+      </Box>
+      <TextField
+        fullWidth
+        multiline
+        minRows={15}
+        maxRows={25}
+        value={code}
+        onChange={(e) => onCodeChange(e.target.value)}
+        InputProps={{
+          readOnly: effectiveReadOnly,
+          style: {
+            fontFamily: 'monospace',
+            fontSize: '0.9rem',
+            backgroundColor: effectiveReadOnly ? '#1e1e1e' : 'inherit',
+            color: effectiveReadOnly ? '#04f500ff' : 'inherit',
+          }
+        }}
+        sx={{ '& .MuiInputBase-root': { p: 1 } }}
+      />
+    </Box>
+  );
+};
+
+CodeEditor.propTypes = {
+  code: PropTypes.string.isRequired,
+  onCodeChange: PropTypes.func.isRequired,
+  isReadOnly: PropTypes.bool,
+};
+
+export default CodeEditor;

--- a/webapp/packages/webui/src/components/Layout.jsx
+++ b/webapp/packages/webui/src/components/Layout.jsx
@@ -11,6 +11,7 @@ import {
   Button,
 } from '@mui/material';
 import ChatIcon from '@mui/icons-material/Chat';
+import SmartToyIcon from '@mui/icons-material/SmartToy';
 import config from '../config';
 
 const Layout = ({ children }) => {
@@ -25,9 +26,17 @@ const Layout = ({ children }) => {
         sx={{ zIndex: (theme) => theme.zIndex.drawer + 1 }}
       >
         <Toolbar>
-          <Typography variant="h6" noWrap component="div" sx={{ flexGrow: 1 }}>
+          <Typography variant="h6" noWrap component="div" sx={{ flexGrow: 1, cursor: 'pointer' }} onClick={() => navigate('/')}>
             {appName}
           </Typography>
+          +          <Button 
+            color="inherit" 
+            startIcon={<SmartToyIcon />}
+            onClick={() => navigate('/agents')}
+            sx={{ mr: 1 }}
+          >
+            Agents
+          </Button>
           <Button 
             color="inherit" 
             startIcon={<ChatIcon />}

--- a/webapp/packages/webui/src/pages/HomePage.jsx
+++ b/webapp/packages/webui/src/pages/HomePage.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
   Box,
@@ -6,45 +6,17 @@ import {
   Button,
   Paper,
   Grid,
-  CircularProgress,
-  Alert,
-  List,
-  ListItem,
-  ListItemText,
-  ListItemIcon,
-  Divider,
 } from '@mui/material';
 import ChatIcon from '@mui/icons-material/Chat';
 import CodeIcon from '@mui/icons-material/Code';
 import SmartToyIcon from '@mui/icons-material/SmartToy';
 import { useAuth } from '../contexts/AuthContext';
-import agentService from '../services/agentService';
+
 
 const HomePage = () => {
   const navigate = useNavigate();
   const { user } = useAuth();
-  const [agents, setAgents] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
-
-  useEffect(() => {
-    const fetchAgents = async () => {
-      try {
-        setLoading(true);
-        setError(null);
-        const savedAgents = await agentService.getAgents();
-        setAgents(savedAgents);
-      } catch (err) {
-        setError('Failed to load saved agents.');
-        console.error(err);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchAgents();
-  }, []);
-
+  
   return (
     <Box sx={{ flexGrow: 1, p: 3 }}>
       <Typography variant="h3" component="h1" gutterBottom>
@@ -97,9 +69,9 @@ const HomePage = () => {
                 backgroundColor: 'action.hover'
               }
             }}
-            onClick={() => navigate('/create-agent/tools')}
+            onClick={() => navigate('/create-agent')}
           >
-            <CodeIcon sx={{ fontSize: 48, mb: 2, color: 'secondary.main' }} /> {/* Using CodeIcon for agent creation */}
+            <CodeIcon sx={{ fontSize: 48, mb: 2, color: 'secondary.main' }} /> 
             <Typography variant="h6">Create New Agent</Typography>
             <Typography variant="body2" color="text.secondary">
               Define tools and behavior for a new AI agent
@@ -110,7 +82,7 @@ const HomePage = () => {
               sx={{ mt: 2 }}
               onClick={(e) => {
                 e.stopPropagation();
-                navigate('/create-agent/tools');
+                navigate('/create-agent');
               }}
             >
               Start Agent Creation
@@ -118,43 +90,31 @@ const HomePage = () => {
           </Paper>
         </Grid>
 
-        <Grid item xs={12}>
-          <Paper sx={{ p: 3, mt: 4 }}>
-            <Typography variant="h5" gutterBottom>
-              My Saved Agents
+        <Grid item xs={12} sm={6} md={4}>
+          <Paper 
+            sx={{ 
+              p: 3, 
+              textAlign: 'center',
+              cursor: 'pointer',
+              '&:hover': {
+                backgroundColor: 'action.hover'
+              }
+            }}
+            onClick={() => navigate('/agents')}
+          >
+            <SmartToyIcon sx={{ fontSize: 48, mb: 2, color: 'success.main' }} />
+            <Typography variant="h6">View Saved Agents</Typography>
+            <Typography variant="body2" color="text.secondary">
+              Browse and manage your previously created agents
             </Typography>
-            <Divider sx={{ mb: 2 }} />
-            {loading && (
-              <Box sx={{ display: 'flex', justifyContent: 'center' }}>
-                <CircularProgress />
-              </Box>
-            )}
-            {error && <Alert severity="error">{error}</Alert>}
-            {!loading && !error && (
-              <List>
-                {agents.length === 0 ? (
-                  <Typography color="text.secondary">
-                    You haven't saved any agents yet. Click "Create New Agent" to get started.
-                  </Typography>
-                ) : (
-                  agents.map((agent) => (
-                    <ListItem
-                      key={agent._id}
-                      button
-                      // onClick={() => navigate(`/agent/${agent._id}`)} // Future feature
-                    >
-                      <ListItemIcon>
-                        <SmartToyIcon />
-                      </ListItemIcon>
-                      <ListItemText
-                        primary={agent.name}
-                        secondary={agent.description}
-                      />
-                    </ListItem>
-                  ))
-                )}
-              </List>
-            )}
+            <Button 
+              variant="contained" 
+              color="success"
+              sx={{ mt: 2 }}
+              onClick={(e) => { e.stopPropagation(); navigate('/agents'); }}
+            >
+              Browse Agents
+            </Button>
           </Paper>
         </Grid>
       </Grid>

--- a/webapp/packages/webui/src/pages/SavedAgentsPage.jsx
+++ b/webapp/packages/webui/src/pages/SavedAgentsPage.jsx
@@ -1,0 +1,87 @@
+import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  Box,
+  Typography,
+  Button,
+  Paper,
+  CircularProgress,
+  Alert,
+  List,
+  ListItem,
+  ListItemText,
+  ListItemIcon,
+  Divider,
+  Container,
+} from '@mui/material';
+import SmartToyIcon from '@mui/icons-material/SmartToy';
+import AddIcon from '@mui/icons-material/Add';
+import agentService from '../services/agentService';
+
+const SavedAgentsPage = () => {
+  const navigate = useNavigate();
+  const [agents, setAgents] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const fetchAgents = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const savedAgents = await agentService.getAgents();
+        setAgents(savedAgents);
+      } catch (err) {
+        setError('Failed to load saved agents.');
+        console.error(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchAgents();
+  }, []);
+
+  return (
+    <Container maxWidth="lg">
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
+        <Typography variant="h4" component="h1">
+          Saved Agents
+        </Typography>
+        <Button
+          variant="contained"
+          startIcon={<AddIcon />}
+          onClick={() => navigate('/create-agent')}
+        >
+          Create New Agent
+        </Button>
+      </Box>
+      
+      <Paper sx={{ p: 3 }}>
+        {loading && <Box sx={{ display: 'flex', justifyContent: 'center' }}><CircularProgress /></Box>}
+        {error && <Alert severity="error">{error}</Alert>}
+        {!loading && !error && (
+          <List>
+            {agents.length === 0 ? (
+              <Typography color="text.secondary" textAlign="center">
+                You haven't saved any agents yet. Click "Create New Agent" to get started.
+              </Typography>
+            ) : (
+              agents.map((agent, index) => (
+                <React.Fragment key={agent._id}>
+                  <ListItem button onClick={() => navigate(`/agent/${agent._id}`)}>
+                    <ListItemIcon><SmartToyIcon /></ListItemIcon>
+                    <ListItemText primary={agent.name} secondary={agent.description} />
+                  </ListItem>
+                  {index < agents.length - 1 && <Divider />}
+                </React.Fragment>
+              ))
+            )}
+          </List>
+        )}
+      </Paper>
+    </Container>
+  );
+};
+
+export default SavedAgentsPage;

--- a/webapp/packages/webui/src/pages/ViewAgent.jsx
+++ b/webapp/packages/webui/src/pages/ViewAgent.jsx
@@ -1,0 +1,236 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import {
+  Box,
+  Typography,
+  Button,
+  Paper,
+  CircularProgress,
+  Alert,
+  Stack,
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
+  TextField,
+  List,
+  ListItem,
+  ListItemText,
+  ListItemIcon,
+} from '@mui/material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import PlayArrowIcon from '@mui/icons-material/PlayArrow';
+import PublishIcon from '@mui/icons-material/Publish';
+import SaveIcon from '@mui/icons-material/Save';
+import WebIcon from '@mui/icons-material/Web';
+import ArticleIcon from '@mui/icons-material/Article';
+
+import { useAgentFlow } from './AgentCreationFlow/AgentCreationFlowContext';
+import agentService from '../services/agentService';
+import CodeEditor from '../components/CodeEditor';
+
+const ViewAgent = () => {
+  const { agentId } = useParams();
+  const navigate = useNavigate();
+  const agentFlowContext = useAgentFlow();
+
+  const [agent, setAgent] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveSuccess, setSaveSuccess] = useState(false);
+
+  const isCreationFlow = !agentId;
+
+  const loadAgentData = useCallback(async () => {
+    setError(null);
+    setLoading(true);
+    try {
+      if (isCreationFlow) {
+        // In creation flow, data comes from context
+        if (!agentFlowContext.generatedCode) {
+            throw new Error("Agent code has not been generated yet. Please go back to the schemas screen.");
+        }
+        setAgent({
+          name: '',
+          description: agentFlowContext.description,
+          tools: agentFlowContext.tools,
+          swaggerSpecs: agentFlowContext.swaggerSpecs,
+          code: agentFlowContext.generatedCode,
+          inputSchema: agentFlowContext.inputSchema,
+          outputSchema: agentFlowContext.outputSchema,
+          invokableModels: agentFlowContext.invokableModels
+        });
+      } else {
+        // In view/edit mode, fetch from API
+        const data = await agentService.getAgent(agentId);
+        setAgent(data);
+      }
+    } catch (err) {
+      setError(err.message || 'Failed to load agent data.');
+    } finally {
+      setLoading(false);
+    }
+  }, [agentId, isCreationFlow, agentFlowContext]);
+
+  useEffect(() => {
+    loadAgentData();
+  }, [loadAgentData]);
+  
+  const handleFieldChange = (field, value) => {
+    setAgent(prev => ({...prev, [field]: value}));
+  };
+
+  const updateContextAndNavigate = (path) => {
+      // Update the context with the current agent state before navigating
+      agentFlowContext.setDescription(agent.description);
+      agentFlowContext.setGeneratedCode(agent.code);
+      agentFlowContext.setTools(agent.tools);
+      agentFlowContext.setSwaggerSpecs(agent.swaggerSpecs);
+      agentFlowContext.setInputSchema(agent.inputSchema);
+      agentFlowContext.setOutputSchema(agent.outputSchema);
+      agentFlowContext.setInvokableModels(agent.invokableModels);
+      navigate(path);
+  };
+
+  const handleRunInSandbox = () => {
+    updateContextAndNavigate('/create-agent/sandbox');
+  };
+
+  const handleDeploy = () => {
+    updateContextAndNavigate('/create-agent/deploy');
+  };
+
+  const handleUpdateAgent = async () => {
+    if (!agentId) return; // Should not happen if button is only for edit mode
+    setError(null);
+    setSaveSuccess(false);
+    setIsSaving(true);
+    try {
+      await agentService.updateAgent(agentId, {
+        name: agent.name,
+        description: agent.description,
+        code: agent.code,
+      });
+      setSaveSuccess(true);
+    } catch (err) {
+        setError(err.message || 'Failed to update agent.');
+    } finally {
+        setIsSaving(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '50vh' }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (error) {
+    return <Alert severity="error">{error}</Alert>;
+  }
+
+  if (!agent) {
+    return <Alert severity="warning">No agent data found.</Alert>;
+  }
+  
+  return (
+    <Paper sx={{ p: 3, maxWidth: 900, margin: 'auto', mt: 4 }}>
+        <Typography variant="h5" component="h2" gutterBottom>
+            {isCreationFlow ? 'Review Your New Agent' : `Viewing Agent: ${agent.name}`}
+        </Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+            {isCreationFlow ? 'Review the generated code and details below. You can make edits before proceeding.' : 'View and edit the details of your saved agent.'}
+        </Typography>
+
+        {saveSuccess && <Alert severity="success" onClose={() => setSaveSuccess(false)}>Agent updated successfully!</Alert>}
+
+        <Accordion defaultExpanded>
+            <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                <Typography>Tools & Specs</Typography>
+            </AccordionSummary>
+            <AccordionDetails>
+                <Typography variant="subtitle1" gutterBottom>MCP Servers</Typography>
+                {Object.keys(agent.tools).length > 0 ? (
+                <List dense>
+                    {Object.entries(agent.tools).map(([url, selectedTools]) => (
+                        <ListItem key={url}>
+                            <ListItemIcon><WebIcon /></ListItemIcon>
+                            <ListItemText primary={url} secondary={selectedTools.length > 0 ? `Selected: ${selectedTools.join(', ')}` : "No specific tools selected"} />
+                        </ListItem>
+                    ))}
+                </List>
+                ) : (<Typography variant="body2" color="text.secondary">No MCP servers configured.</Typography>)}
+                <Typography variant="subtitle1" gutterBottom sx={{mt: 2}}>Swagger/OpenAPI Specs</Typography>
+                {agent.swaggerSpecs.length > 0 ? (
+                <List dense>
+                    {agent.swaggerSpecs.map(spec => (
+                        <ListItem key={spec.name}>
+                            <ListItemIcon><ArticleIcon /></ListItemIcon>
+                            <ListItemText primary={spec.name} />
+                        </ListItem>
+                    ))}
+                </List>
+                ) : (<Typography variant="body2" color="text.secondary">No Swagger specs uploaded.</Typography>)}
+            </AccordionDetails>
+        </Accordion>
+
+        <Accordion>
+            <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                <Typography>Description</Typography>
+            </AccordionSummary>
+            <AccordionDetails>
+                <TextField 
+                    fullWidth
+                    multiline
+                    rows={4}
+                    label="Agent Description"
+                    value={agent.description}
+                    onChange={(e) => handleFieldChange('description', e.target.value)}
+                />
+            </AccordionDetails>
+        </Accordion>
+
+        <Accordion defaultExpanded>
+            <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                <Typography>Agent Code</Typography>
+            </AccordionSummary>
+            <AccordionDetails>
+                <CodeEditor code={agent.code} onCodeChange={(newCode) => handleFieldChange('code', newCode)} isReadOnly={!isCreationFlow}/>
+            </AccordionDetails>
+        </Accordion>
+
+        <Stack direction="row" spacing={2} justifyContent="flex-end" sx={{mt: 3}}>
+            <Button
+                variant="outlined"
+                startIcon={<PlayArrowIcon />}
+                onClick={handleRunInSandbox}
+            >
+                Run in Sandbox
+            </Button>
+            <Button
+                variant="outlined"
+                color="secondary"
+                startIcon={<PublishIcon />}
+                onClick={handleDeploy}
+            >
+                Deploy Agent
+            </Button>
+            {!isCreationFlow && (
+                <Button
+                    variant="contained"
+                    color="primary"
+                    startIcon={isSaving ? <CircularProgress size={20} color="inherit" /> : <SaveIcon />}
+                    onClick={handleUpdateAgent}
+                    disabled={isSaving}
+                >
+                    {isSaving ? 'Updating...' : 'Update Agent'}
+                </Button>
+            )}
+        </Stack>
+    </Paper>
+  );
+};
+
+export default ViewAgent;

--- a/webapp/packages/webui/src/services/agentService.js
+++ b/webapp/packages/webui/src/services/agentService.js
@@ -107,6 +107,28 @@ class AgentService {
       throw error;
     }
   }
+
+  async updateAgent(agentId, agentData) {
+    try {
+      const response = await fetch(`${API_BASE_URL}/agents/${agentId}`, {
+        method: 'PUT', // Or PATCH if the backend supports partial updates
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept': 'application/json',
+        },
+        body: JSON.stringify(agentData),
+      });
+
+      const data = await response.json();
+      if (!response.ok) {
+        throw new Error(data.detail || 'Failed to update the agent.');
+      }
+      return data;
+    } catch (error) {
+      console.error(`[AgentService] Error updating agent ${agentId}:`, error);
+      throw error;
+    }
+  }  
 }
 
 export default new AgentService();


### PR DESCRIPTION
closes #368 
closes #369 
closes #370 

Improve agents listing on top page (368)
<img width="1153" height="411" alt="image" src="https://github.com/user-attachments/assets/fb1dde54-434c-477a-9ea5-3eee65bcf9bc" />

Create View Agents page (no-jira)
<img width="1393" height="347" alt="image" src="https://github.com/user-attachments/assets/a2874a01-f30d-4bcb-9b53-32b218868f13" />

Create View Agent Page (369)
<img width="1448" height="524" alt="image" src="https://github.com/user-attachments/assets/1942ee3e-022e-41d1-a56a-d7dfb794269a" />

Add Save Button (370)
Code screen is now part of ViewAgentPage
<img width="984" height="369" alt="image" src="https://github.com/user-attachments/assets/1dcd4178-cccd-4268-bf2e-6df2b13041b0" />

Title links back to home page (no-jira)
this was just bugging me for a while, now when you click on 'Gofannon WebApp' in the top right, it takes you back to home. 