### PR TITLE
Replace junk in top corner + add logout button

### DIFF
--- a/webapp/packages/webui/src/components/Layout.jsx
+++ b/webapp/packages/webui/src/components/Layout.jsx
@@ -1,3 +1,4 @@
+// webapp/packages/webui/src/components/Layout.jsx
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useNavigate } from 'react-router-dom';
@@ -8,11 +9,9 @@ import {
   Container,
   Box,
   CssBaseline,
-  Button,
 } from '@mui/material';
-import ChatIcon from '@mui/icons-material/Chat';
-import SmartToyIcon from '@mui/icons-material/SmartToy';
 import config from '../config';
+import ProfileMenu from './ProfileMenu';
 
 const Layout = ({ children }) => {
   const navigate = useNavigate();
@@ -29,21 +28,7 @@ const Layout = ({ children }) => {
           <Typography variant="h6" noWrap component="div" sx={{ flexGrow: 1, cursor: 'pointer' }} onClick={() => navigate('/')}>
             {appName}
           </Typography>
-          +          <Button 
-            color="inherit" 
-            startIcon={<SmartToyIcon />}
-            onClick={() => navigate('/agents')}
-            sx={{ mr: 1 }}
-          >
-            Agents
-          </Button>
-          <Button 
-            color="inherit" 
-            startIcon={<ChatIcon />}
-            onClick={() => navigate('/chat')}
-          >
-            Chat
-          </Button>
+          <ProfileMenu />
         </Toolbar>
       </AppBar>
       <Box

--- a/webapp/packages/webui/src/components/ProfileMenu.jsx
+++ b/webapp/packages/webui/src/components/ProfileMenu.jsx
@@ -1,0 +1,57 @@
+// webapp/packages/webui/src/components/ProfileMenu.jsx
+import React, { useState } from 'react';
+import { IconButton, Menu, MenuItem } from '@mui/material';
+import AccountCircle from '@mui/icons-material/AccountCircle';
+import { useAuth } from '../contexts/AuthContext';
+
+const ProfileMenu = () => {
+  const { logout } = useAuth();
+  const [anchorEl, setAnchorEl] = useState(null);
+
+  const handleMenu = (event) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const handleLogout = () => {
+    logout();
+    handleClose();
+  };
+
+  return (
+    <div>
+      <IconButton
+        size="large"
+        aria-label="account of current user"
+        aria-controls="menu-appbar"
+        aria-haspopup="true"
+        onClick={handleMenu}
+        color="inherit"
+      >
+        <AccountCircle />
+      </IconButton>
+      <Menu
+        id="menu-appbar"
+        anchorEl={anchorEl}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'right',
+        }}
+        keepMounted
+        transformOrigin={{
+          vertical: 'top',
+          horizontal: 'right',
+        }}
+        open={Boolean(anchorEl)}
+        onClose={handleClose}
+      >
+        <MenuItem onClick={handleLogout}>Logout</MenuItem>
+      </Menu>
+    </div>
+  );
+};
+
+export default ProfileMenu;


### PR DESCRIPTION
Closes #383 

Replaces 'Chat' and 'Agents' links in toolbar with a profile icon and a drop down menu with a 'logout' button.

<img width="652" height="469" alt="image" src="https://github.com/user-attachments/assets/c1d13bb5-148c-4684-9d9f-bcea0c21ff33" />

Logout button seems to work. 