### PR TITLE
Add reasoning_effort

### DIFF
--- a/webapp/packages/api/user-service/config/gemini/__init__.py
+++ b/webapp/packages/api/user-service/config/gemini/__init__.py
@@ -1,6 +1,7 @@
 
 
 models = {
+
     "gemini-2.5-pro": {
         "parameters": {
             "temperature": {
@@ -10,99 +11,20 @@ models = {
                 "max": 2.0,
                 "description": "Temperature - Controls randomness"
             },
-            # "top_p": {
-            #     "type": "float",
-            #     "default": None,
-            #     "min": 0.0,
-            #     "max": 1.0,
-            #     "description": "TopP - Nucleus sampling"
-            # },
-            # "max_tokens": { #TODO: Verify max tokens for Gemini
-            #     "type": "integer",
-            #     "default": None, 
-            #     "min": 1,
-            #     "max": 1048576,
-            #     "description": "Maximum tokens in response"
-            # },
-            # "max_ completion_tokens": {
-            #     "type": "integer",
-            #     "default": 65536,
-            #     "min": 1,
-            #     "max": 65536,
-            #     "description": "Maximum completion tokens"
-            # },
-            # "tools": {
-            #     "type": "list_choice",
-            #     "default": [],
-            #     "choices": ["googleSearch", "googleMaps", "urlContext", "codeExecution"],
-            #     "description": "Gemini Tools to enable during generation"
-            # },
-            # "tool_choice": { # if you don't want it calling tools, don't give it any tools...
-            #     "type": "choice",
-            #     "default": "auto",
-            #     "choices": ["auto", "none"],
-            #     "description": "Tool selection mode"
-            # },
-            
-            # "response_format": { # Need to set response_format: {"type": ...} in request body
-            #     "type": "choice",
-            #     "default": "text",
-            #     "choices": ["text", "json_object"],
-            #     "description": "Format of the response"
-            # },
-            # "n" : {
-            #     "type": "integer",
-            #     "default": 1,
-            #     "min": 1,
-            #     "max": 5,
-            #     "description": "Number of completions to generate"
-            # },
-            # "stop": {
-            #     "type": "list_string",
-            #     "default": [],
-            #     "description": "Sequences where the API will stop generating."
-            # },
-            # "logprobs": {
-            #     "type": "integer",
-            #     "default": 0,
-            #     "min": 0,
-            #     "max": 5,
-            #     "description": "Include logprobs on the logprobs most likely tokens"
-            # },
-            # "frequency_penalty": {
-            #     "type": "float",
-            #     "default": 0.0,
-            #     "min": -2.0,
-            #     "max": 2.0,
-            #     "description": "Penalty for token repetition"
-            # },
-            # "modalities": {
-            #     "type": "list_choice",
-            #     "default": ["text"],
-            #     "choices": ["text", "image", "video", "audio"],
-            #     "description": "Modalities to include in generation"
-            # },  
-            # "parallel_tool_calls": {
-            #     "type": "boolean",
-            #     "default": False,
-            #     "description": "Enable parallel tool calls"
-            # },
-            # "web_search_options": {
-            #     "type": "object",
-            #     "default": {
-            #         "num_results": 3,
-            #         "region": "us",
-            #         "language": "en"
-            #     },
-            #     "description": "Options for web search tool"
-            # },
             "reasoning_effort": {
                 "type": "choice", 
                 "default": "disable", 
                 "choices": ["disable", "low", "medium", "high"],
                 "description": "Reasoning Effort: Effort level for reasoning during generation" 
             },
-        }
+        },
+        "built_in_tools": [
+                    {
+                        "id": "google_search",
+                        "description": "Performs a Google search.",
+                        "tool_config": {"google_search": {}}
+                    }
+                ],
     },
     "gemini-2.5-flash": {
         "parameters": {
@@ -111,101 +33,22 @@ models = {
                 "default": 1.0,
                 "min": 0.0,
                 "max": 2.0,
-                "description": "Temperature - Controls randomness",
+                "description": "Temperature - Controls randomness"
             },
-            # "top_p": {
-            #     "type": "float",
-            #     "default": None,
-            #     "min": 0.0,
-            #     "max": 1.0,
-            #     "description": "TopP - Nucleus sampling"
-            # },
-            # "max_tokens": { #TODO: Verify max tokens for Gemini
-            #     "type": "integer",
-            #     "default": None, 
-            #     "min": 1,
-            #     "max": 1048576,
-            #     "description": "Maximum tokens in response"
-            # },
-            # "max_ completion_tokens": {
-            #     "type": "integer",
-            #     "default": 65536,
-            #     "min": 1,
-            #     "max": 65536,
-            #     "description": "Maximum completion tokens"
-            # },
-            # "tools": { 
-            #     "type": "list_choice",
-            #     "default": [],
-            #     "choices": ["googleSearch", "googleMaps", "urlContext", "codeExecution"],
-            #     "description": "Gemini Tools to enable during generation"
-            # },
-            # "tool_choice": { # if you don't want it calling tools, don't give it any tools...
-            #     "type": "choice",
-            #     "default": "auto",
-            #     "choices": ["auto", "none"],
-            #     "description": "Tool selection mode"
-            # },
-            
-            # "response_format": { # Need to set response_format: {"type": ...} in request body
-            #     "type": "choice",
-            #     "default": "text",
-            #     "choices": ["text", "json_object"],
-            #     "description": "Format of the response"
-            # },
-            # "n" : {
-            #     "type": "integer",
-            #     "default": 1,
-            #     "min": 1,
-            #     "max": 5,
-            #     "description": "Number of completions to generate"
-            # },
-            # "stop": {
-            #     "type": "list_string",
-            #     "default": [],
-            #     "description": "Sequences where the API will stop generating."
-            # },
-            # "logprobs": {
-            #     "type": "integer",
-            #     "default": 0,
-            #     "min": 0,
-            #     "max": 5,
-            #     "description": "Include logprobs on the logprobs most likely tokens"
-            # },
-            # "frequency_penalty": {
-            #     "type": "float",
-            #     "default": 0.0,
-            #     "min": -2.0,
-            #     "max": 2.0,
-            #     "description": "Penalty for token repetition"
-            # },
-            # "modalities": {
-            #     "type": "list_choice",
-            #     "default": ["text"],
-            #     "choices": ["text", "image", "video", "audio"],
-            #     "description": "Modalities to include in generation"
-            # },  
-            # "parallel_tool_calls": {
-            #     "type": "boolean",
-            #     "default": False,
-            #     "description": "Enable parallel tool calls"
-            # },
-            # "web_search_options": {
-            #     "type": "object",
-            #     "default": {
-            #         "num_results": 3,
-            #         "region": "us",
-            #         "language": "en"
-            #     },
-            #     "description": "Options for web search tool"
-            # },
-                "reasoning_effort": {
+            "reasoning_effort": {
                 "type": "choice", 
                 "default": "disable", 
                 "choices": ["disable", "low", "medium", "high"],
                 "description": "Reasoning Effort: Effort level for reasoning during generation" 
             },
-        }
+        },
+        "built_in_tools": [
+                    {
+                        "id": "google_search",
+                        "description": "Performs a Google search.",
+                        "tool_config": {"google_search": {}}
+                    }
+                ],
     },
     "gemini-2.5-flash-lite": {
         "parameters": {
@@ -216,98 +59,19 @@ models = {
                 "max": 2.0,
                 "description": "Temperature - Controls randomness"
             },
-            # "top_p": {
-            #     "type": "float",
-            #     "default": None,
-            #     "min": 0.0,
-            #     "max": 1.0,
-            #     "description": "TopP - Nucleus sampling"
-            # },
-            # "max_tokens": { #TODO: Verify max tokens for Gemini
-            #     "type": "integer",
-            #     "default": None, 
-            #     "min": 1,
-            #     "max": 1048576,
-            #     "description": "Maximum tokens in response"
-            # },
-            # "max_ completion_tokens": {
-            #     "type": "integer",
-            #     "default": 65536,
-            #     "min": 1,
-            #     "max": 65536,
-            #     "description": "Maximum completion tokens"
-            # },
-            # "tools": { 
-            #     "type": "list_choice",
-            #     "default": [],
-            #     "choices": ["googleSearch", "googleMaps", "urlContext", "codeExecution"],
-            #     "description": "Gemini Tools to enable during generation"
-            # },
-            # "tool_choice": { # if you don't want it calling tools, don't give it any tools...
-            #     "type": "choice",
-            #     "default": "auto",
-            #     "choices": ["auto", "none"],
-            #     "description": "Tool selection mode"
-            # },
-            
-            # "response_format": { # Need to set response_format: {"type": ...} in request body
-            #     "type": "choice",
-            #     "default": "text",
-            #     "choices": ["text", "json_object"],
-            #     "description": "Format of the response"
-            # },
-            # "n" : {
-            #     "type": "integer",
-            #     "default": 1,
-            #     "min": 1,
-            #     "max": 5,
-            #     "description": "Number of completions to generate"
-            # },
-            # "stop": {
-            #     "type": "list_string",
-            #     "default": [],
-            #     "description": "Sequences where the API will stop generating."
-            # },
-            # "logprobs": {
-            #     "type": "integer",
-            #     "default": 0,
-            #     "min": 0,
-            #     "max": 5,
-            #     "description": "Include logprobs on the logprobs most likely tokens"
-            # },
-            # "frequency_penalty": {
-            #     "type": "float",
-            #     "default": 0.0,
-            #     "min": -2.0,
-            #     "max": 2.0,
-            #     "description": "Penalty for token repetition"
-            # },
-            # "modalities": {
-            #     "type": "list_choice",
-            #     "default": ["text"],
-            #     "choices": ["text", "image", "video", "audio"],
-            #     "description": "Modalities to include in generation"
-            # },  
-            # "parallel_tool_calls": {
-            #     "type": "boolean",
-            #     "default": False,
-            #     "description": "Enable parallel tool calls"
-            # },
-            # "web_search_options": {
-            #     "type": "object",
-            #     "default": {
-            #         "num_results": 3,
-            #         "region": "us",
-            #         "language": "en"
-            #     },
-            #     "description": "Options for web search tool"
-            # },
-                "reasoning_effort": {
+            "reasoning_effort": {
                 "type": "choice", 
                 "default": "disable", 
                 "choices": ["disable", "low", "medium", "high"],
                 "description": "Reasoning Effort: Effort level for reasoning during generation" 
             },
-        }
+        },
+        "built_in_tools": [
+                    {
+                        "id": "google_search",
+                        "description": "Performs a Google search.",
+                        "tool_config": {"google_search": {}}
+                    }
+                ],
     }
 }

--- a/webapp/packages/api/user-service/config/provider_config.py
+++ b/webapp/packages/api/user-service/config/provider_config.py
@@ -6,8 +6,23 @@ PROVIDER_CONFIG = {
         "api_key_env_var": "OPENAI_API_KEY",
         "models": {
             "gpt-5-mini-2025-08-07": {
+                "api_style": "responses",
+                "returns_thoughts": True,
                 "parameters": {
-                }
+                    "reasoning_effort": {
+                        "type": "choice",
+                        "default": "disable",
+                        "choices": ["disable", "low", "medium", "high"],
+                        "description": "Controls the reasoning effort of the model."
+                    }
+                },
+                "built_in_tools": [
+                    {
+                        "id": "web_search",
+                        "description": "Performs a web search.",
+                        "tool_config": {"type": "web_search_preview", "search_context_size": "low"}
+                    }
+                ]
             }, 
             "gpt-4": {
                 "parameters": {
@@ -109,30 +124,20 @@ PROVIDER_CONFIG = {
     },
     "gemini": {
         "api_key_env_var": "GEMINI_API_KEY",
-        "models": {
-            "gemini-2.5-pro": {
-                "parameters": {
-                    "reasoning_effort": {
-                        "type": "choice", 
-                        "default": 0,
-                        "choices": ["disable", "low", "medium", "high"],
-                    }
-                },
-                "built_in_tools": [
-                    {
-                        "id": "google_search",
-                        "description": "Performs a Google search.",
-                        "tool_config": {"google_search": {}}
-                    }
-                ]
-            }
-        }
+        "models":  gemini_models,
     },
     "anthropic": {
         "api_key_env_var": "ANTHROPIC_API_KEY",
         "models": {
             "claude-3-opus": {
+                "returns_thoughts": True,
                 "parameters": {
+                    "reasoning_effort": {
+                        "type": "choice",
+                        "default": "disable",
+                        "choices": ["disable", "low", "medium", "high"],
+                        "description": "Controls the reasoning effort of the model."
+                    },
                     "temperature": {
                         "type": "float",
                         "default": 0.7,
@@ -171,7 +176,14 @@ PROVIDER_CONFIG = {
                 ]
             },
             "claude-3-sonnet": {
+                "returns_thoughts": True,
                 "parameters": {
+                    "reasoning_effort": {
+                        "type": "choice",
+                        "default": "disable",
+                        "choices": ["disable", "low", "medium", "high"],
+                        "description": "Controls the reasoning effort of the model."
+                    },
                     "temperature": {
                         "type": "float",
                         "default": 0.7,

--- a/webapp/packages/api/user-service/services/llm_service.py
+++ b/webapp/packages/api/user-service/services/llm_service.py
@@ -28,11 +28,18 @@ async def call_llm(
         "messages": messages,
         **parameters,
     }
+
+    reasoning_effort = kwargs.pop('reasoning_effort', 'disable')
+
     if tools:
         kwargs["tools"] = tools
 
     if api_style == "responses":
         # Use aresponses and aget_responses for OpenAI's special tools like built-in web search
+        kwargs.pop('messages', None) # aresponses uses 'input' not 'messages'
+        if reasoning_effort != 'disable':
+            kwargs['reasoning'] = {'effort': reasoning_effort, 'summary': 'auto'}
+
         try:
             # Note: The 'input' for aresponses is different from 'messages'
             input_text = next((msg["content"] for msg in reversed(messages) if msg["role"] == "user"), "")
@@ -47,10 +54,14 @@ async def call_llm(
                     break
             
             if final_response:
+                # Extract thoughts/summary from the first output block
+                if len(final_response.output) > 0 and final_response.output[0] and hasattr(final_response.output[0], 'summary') and final_response.output[0].summary:
+                    summary_texts = [s.text for s in final_response.output[0].summary if hasattr(s, 'text')]
+                    thoughts = {"summary": summary_texts}
+                elif len(final_response.output) > 0 and final_response.output[0]: # Fallback for other tool outputs
+                     thoughts = final_response.output[0].model_dump()
                 
-                if len(final_response.output) > 0 and final_response.output[0]:
-                    thoughts = final_response.output[0].model_dump()
-                
+                # Extract content from the second output block (or first if it's the only one with content)
                 if len(final_response.output) > 1 and final_response.output[1] and final_response.output[1].content:
                     content = final_response.output[1].content[0].text
                 elif len(final_response.output) > 0 and final_response.output[0] and final_response.output[0].content:
@@ -64,23 +75,35 @@ async def call_llm(
             raise
     else:
         # Standard acompletion call for most models
+        if reasoning_effort != 'disable':
+            kwargs['reasoning_effort'] = reasoning_effort
+
         response = await litellm.acompletion(**kwargs)
         message = response.choices[0].message
         content = message.content if isinstance(message.content, str) else ""
         
-        # Extract thoughts/tool calls
+        # Extract various forms of "thoughts"
+        thoughts_payload = {}
         if message.tool_calls:
-            thoughts = [tc.model_dump() for tc in message.tool_calls]
-        elif isinstance(message.content, list): # Handle Anthropic's block-based content
+            thoughts_payload['tool_calls'] = [tc.model_dump() for tc in message.tool_calls]
+        
+        if hasattr(message, 'reasoning_content') and message.reasoning_content:
+            thoughts_payload['reasoning_content'] = message.reasoning_content
+
+        if isinstance(message.content, list): # Handle Anthropic's block-based content
             content_blocks = message.content
             thought_blocks = [block for block in content_blocks if block.get("type") == "thought"]
             tool_use_blocks = [block for block in content_blocks if block.get("type") == "tool_use"]
             text_blocks = [block.get("text", "") for block in content_blocks if block.get("type") == "text"]
             
-            if thought_blocks or tool_use_blocks:
-                thoughts = {"thoughts": thought_blocks, "tool_uses": tool_use_blocks}
+            if thought_blocks:
+                thoughts_payload['anthropic_thoughts'] = thought_blocks
+            if tool_use_blocks:
+                thoughts_payload['anthropic_tool_uses'] = tool_use_blocks
             
             content = "\n".join(text_blocks)
+
+        thoughts = thoughts_payload if thoughts_payload else None
 
     # Ensure thoughts are JSON serializable
     if thoughts is not None:


### PR DESCRIPTION
Closes #419 

Reasoining effort is configured per model via 
```
parameters."reasoning_effort": {
                "type": "choice", 
                "default": "disable", 
                "choices": ["disable", "low", "medium", "high"],
                "description": "Reasoning Effort: Effort level for reasoning during generation" 
            },
```

Older models don't return thoughts, so we also add `"returns_thoughts": True,`

GPT-5 Models / responsesAPI is a whole other thing, but it's addressed. 

When selecting an LLM, reasoning effort is just a drop down:
<img width="657" height="641" alt="image" src="https://github.com/user-attachments/assets/4c21291e-98a9-4b67-9255-79bf1b962e6b" />

Thoughts appear under the response:
<img width="615" height="242" alt="image" src="https://github.com/user-attachments/assets/640bb7fa-153b-443b-9cd1-e13c0980204e" />

You can open them up and see
<img width="737" height="470" alt="image" src="https://github.com/user-attachments/assets/b65fe632-85f2-41c6-a4c2-240fdefd78fa" />

Shots above are gemini, here is openAI also working
<img width="770" height="518" alt="image" src="https://github.com/user-attachments/assets/a4fbeb78-807c-432a-a66a-d9ab87947b4d" />
