### PR TITLE
Make UI and API routes extensible for external repositories

### DIFF
--- a/webapp/README.md
+++ b/webapp/README.md
@@ -42,3 +42,126 @@ This monorepo contains the complete scaffolding for the Gofannon web application
     - API: [http://localhost:8000/docs](http://localhost:8000/docs) (Swagger UI)
 
 This setup uses a mock authentication provider, allowing you to bypass login and develop features directly. Storage is handled by a local MinIO container that simulates an S3-compatible service.
+
+## Extending from an external repository
+
+External repositories can copy the `webapp` directory and layer in new UI routes, cards, and API endpoints by updating configuration files instead of rewriting core code.
+
+- **Web UI routes:** Add or override entries in `packages/webui/src/config/routes/overrides.js`. Each route can specify an `element`, whether it should render inside the shared `Layout`, whether it requires authentication, and any wrapper providers.
+- **Cards:** Register new cards via `packages/webui/src/extensions/index.js` (imported automatically on startup) and give them an ordering entry in `packages/webui/src/extensions/cards/config/defaultCardsConfig.js`.
+- **API endpoints:** Provide additional FastAPI registrars and list them with the `GOFANNON_API_ROUTE_REGISTRARS` environment variable or by editing `packages/api/user-service/config/routes_config.py`.
+
+### Example: adding an "Echo" experience
+
+Below is a full example of what an external repository would add after copying `webapp/` to introduce a new Echo card, page, and API endpoint. File paths are relative to the copied `webapp` directory.
+
+1. **Add a new page at `packages/webui/src/pages/EchoPage.jsx`:**
+    ```jsx
+    import React, { useState } from 'react';
+    import { Box, Button, Stack, TextField, Typography } from '@mui/material';
+    import apiClient from '../services/apiClient';
+
+    const EchoPage = () => {
+      const [input, setInput] = useState('');
+      const [result, setResult] = useState('');
+
+      const sendEcho = async () => {
+        const response = await apiClient.post('/echo', { text: input });
+        setResult(response.data.echo);
+      };
+
+      return (
+        <Stack spacing={3} maxWidth={520}>
+          <Typography variant="h4">Echo</Typography>
+          <TextField label="Message" value={input} onChange={(e) => setInput(e.target.value)} fullWidth />
+          <Button variant="contained" onClick={sendEcho}>Send</Button>
+          {result && (
+            <Box p={2} bgcolor="grey.100" borderRadius={1}>
+              <Typography variant="subtitle2">Response</Typography>
+              <Typography>{result}</Typography>
+            </Box>
+          )}
+        </Stack>
+      );
+    };
+
+    export default EchoPage;
+    ```
+
+2. **Expose the route in `packages/webui/src/config/routes/overrides.js`:**
+    ```js
+    import EchoPage from '../../pages/EchoPage';
+
+    const overrideRoutesConfig = {
+      routes: [
+        {
+          id: 'echo',
+          path: '/echo',
+          element: <EchoPage />, // Renders inside the shared Layout + PrivateRoute by default
+        },
+      ],
+    };
+
+    export default overrideRoutesConfig;
+    ```
+
+3. **Register a card in `packages/webui/src/extensions/cards/EchoCard.jsx` and wire it up in `packages/webui/src/extensions/index.js`:**
+    ```jsx
+    // packages/webui/src/extensions/cards/EchoCard.jsx
+    import RecordVoiceOverIcon from '@mui/icons-material/RecordVoiceOver';
+
+    const EchoCard = {
+      id: 'echo',
+      title: 'Try Echo',
+      description: 'Send a message and see it echoed back by the API.',
+      buttonText: 'Open Echo',
+      icon: <RecordVoiceOverIcon />,
+      defaultOrder: 7,
+      onAction: ({ navigate }) => navigate('/echo'),
+    };
+
+    export default EchoCard;
+    ```
+
+    ```js
+    // packages/webui/src/extensions/index.js
+    import EchoCard from './cards/EchoCard';
+    import { registerExternalCardRegistrar } from './cards/cardRegistry';
+
+    registerExternalCardRegistrar(({ registerCard }) => registerCard(EchoCard));
+    ```
+
+    Also add the card to the ordering config (or set `CARD_CONFIG_OVERRIDES` in the environment):
+    ```js
+    // packages/webui/src/extensions/cards/config/defaultCardsConfig.js
+    const defaultCardsConfig = {
+      cards: [
+        // ...existing cards
+        { id: 'echo', order: 7, enabled: true },
+      ],
+    };
+
+    export default defaultCardsConfig;
+    ```
+
+4. **Add the API endpoint via a registrar (`packages/api/user-service/routes/echo.py`):**
+    ```python
+    from fastapi import APIRouter
+
+    router = APIRouter()
+
+    @router.post("/echo")
+    async def echo(payload: dict):
+        return {"echo": payload.get("text", "")}
+
+    def register_echo_routes(app):
+        app.include_router(router)
+    ```
+
+    Reference the registrar when launching the API:
+    ```bash
+    export GOFANNON_API_ROUTE_REGISTRARS='["main:register_builtin_routes", "routes.echo:register_echo_routes"]'
+    uvicorn main:app --reload
+    ```
+
+With those files in place, running the normal build commands will surface the Echo card on the home screen, route users to the new `/echo` page, and round-trip their text through the `/echo` API endpoint.

--- a/webapp/packages/api/user-service/config/routes_config.py
+++ b/webapp/packages/api/user-service/config/routes_config.py
@@ -1,0 +1,57 @@
+"""Route configuration for FastAPI app.
+
+This file defines how route registrars are located so that extension
+repositories can add new API endpoints by providing additional registrars
+without modifying the FastAPI initialization logic.
+"""
+import json
+import os
+from importlib import import_module
+from typing import Callable, Iterable, List
+
+DEFAULT_ROUTE_REGISTRARS: List[str] = ["main:register_builtin_routes"]
+
+
+def _parse_registrar_list(raw_value) -> List[str]:
+    if raw_value is None:
+        return []
+
+    if isinstance(raw_value, str):
+        try:
+            parsed = json.loads(raw_value)
+            if isinstance(parsed, list):
+                return [entry for entry in parsed if isinstance(entry, str)]
+        except json.JSONDecodeError:
+            return []
+
+    if isinstance(raw_value, Iterable):
+        return [entry for entry in raw_value if isinstance(entry, str)]
+
+    return []
+
+
+def _resolve_registrar(import_path: str) -> Callable:
+    """Load a registrar from a string like ``module:function``."""
+    if ":" not in import_path:
+        raise ValueError(f"Invalid registrar path '{import_path}'. Expected format module:function")
+
+    module_name, func_name = import_path.split(":", 1)
+    module = import_module(module_name)
+    registrar = getattr(module, func_name)
+    if not callable(registrar):
+        raise ValueError(f"Registrar '{import_path}' is not callable")
+    return registrar
+
+
+def load_route_registrars() -> List[Callable]:
+    env_override = _parse_registrar_list(os.getenv("GOFANNON_API_ROUTE_REGISTRARS"))
+    configured_registrars = []
+
+    for registrar_path in [*DEFAULT_ROUTE_REGISTRARS, *env_override]:
+        try:
+            registrar_callable = _resolve_registrar(registrar_path)
+            configured_registrars.append(registrar_callable)
+        except Exception as error:  # pragma: no cover - defensive logging only
+            print(f"Failed to load route registrar '{registrar_path}': {error}")
+
+    return configured_registrars

--- a/webapp/packages/api/user-service/main.py
+++ b/webapp/packages/api/user-service/main.py
@@ -1,5 +1,5 @@
 # webapp/packages/api/user-service/main.py
-from fastapi import FastAPI, UploadFile, File, Depends, HTTPException, BackgroundTasks, Request
+from fastapi import APIRouter, FastAPI, UploadFile, File, Depends, HTTPException, BackgroundTasks, Request
 from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
 from typing import Annotated, Optional, Dict, Any, List
@@ -16,7 +16,6 @@ import httpx
 import firebase_admin
 import yaml
 from firebase_admin import credentials, auth
-from fastapi import Depends
 from fastapi.security import OAuth2PasswordBearer
 
 from services.database_service import get_database_service, DatabaseService
@@ -34,6 +33,7 @@ from services.llm_service import call_llm
 
 # Import the shared provider configuration
 from config.provider_config import PROVIDER_CONFIG as APP_PROVIDER_CONFIG
+from config.routes_config import load_route_registrars
 from models.agent import (
     GenerateCodeRequest, GenerateCodeResponse, RunCodeRequest, 
     RunCodeResponse, Agent, CreateAgentRequest, Deployment, DeployedApi
@@ -58,6 +58,7 @@ if settings.APP_ENV == "firebase":
         print(f"Error initializing Firebase Admin SDK: {e}")
 
 app = FastAPI()
+router = APIRouter()
 
 # Add observability middleware
 app.add_middleware(ObservabilityMiddleware)
@@ -300,11 +301,11 @@ def get_available_providers():
     return available_providers
 
 # --- Routes ---
-@app.get("/")
+@router.get("/")
 def read_root():
     return {"Hello": "World", "Service": "User-Service"}
 
-@app.post("/log/client", status_code=202)
+@router.post("/log/client", status_code=202)
 async def log_client_event(
     payload: ClientLogPayload,
     request: Request,
@@ -328,12 +329,12 @@ async def log_client_event(
     )
     return {"status": "logged"}
 
-@app.get("/providers")
+@router.get("/providers")
 def get_providers():
     """Get all available providers and their configurations"""
     return get_available_providers()
 
-@app.get("/providers/{provider}")
+@router.get("/providers/{provider}")
 def get_provider_config_route(provider: str):
     """Get configuration for a specific provider"""
     available_providers = get_available_providers()
@@ -341,7 +342,7 @@ def get_provider_config_route(provider: str):
         raise HTTPException(status_code=404, detail="Provider not found or not configured")
     return available_providers[provider]
 
-@app.get("/providers/{provider}/models")
+@router.get("/providers/{provider}/models")
 def get_provider_models(provider: str):
     """Get available models for a provider"""
     available_providers = get_available_providers()
@@ -349,7 +350,7 @@ def get_provider_models(provider: str):
         raise HTTPException(status_code=404, detail="Provider not found or not configured")
     return list(available_providers[provider]["models"].keys())
 
-@app.get("/providers/{provider}/models/{model}")
+@router.get("/providers/{provider}/models/{model}")
 def get_model_config(provider: str, model: str):
     """Get configuration for a specific model"""
     available_providers = get_available_providers()
@@ -359,7 +360,7 @@ def get_model_config(provider: str, model: str):
         raise HTTPException(status_code=404, detail="Model not found")
     return available_providers[provider]["models"][model]
 
-@app.post("/chat")
+@router.post("/chat")
 async def chat(request: ChatRequest, req: Request, background_tasks: BackgroundTasks, user: dict = Depends(get_current_user)):
     """Submit a chat request and get a ticket ID"""
     ticket_id = str(uuid.uuid4())
@@ -372,7 +373,7 @@ async def chat(request: ChatRequest, req: Request, background_tasks: BackgroundT
         status="pending"
     )
 
-@app.get("/chat/{ticket_id}")
+@router.get("/chat/{ticket_id}")
 async def get_chat_status(ticket_id: str, db: DatabaseService = Depends(get_db), user: dict = Depends(get_current_user)):
     """Get the status and result of a chat request"""
     try:
@@ -388,7 +389,7 @@ async def get_chat_status(ticket_id: str, db: DatabaseService = Depends(get_db),
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
-@app.post("/sessions/{session_id}/config")
+@router.post("/sessions/{session_id}/config")
 async def update_session_config(session_id: str, config: ProviderConfig, db: DatabaseService = Depends(get_db), user: dict = Depends(get_current_user)):
     """Update session configuration"""
     try:
@@ -405,25 +406,25 @@ async def update_session_config(session_id: str, config: ProviderConfig, db: Dat
     db.save("sessions", session_id, session_doc)
     return {"message": "Configuration updated", "session_id": session_id}
 
-@app.get("/sessions/{session_id}/config")
+@router.get("/sessions/{session_id}/config")
 async def get_session_config(session_id: str, db: DatabaseService = Depends(get_db), user: dict = Depends(get_current_user)):
     """Get session configuration"""
     session_doc = db.get("sessions", session_id)
     return session_doc.get("provider_config")
 
-@app.delete("/sessions/{session_id}")
+@router.delete("/sessions/{session_id}")
 async def delete_session(session_id: str, db: DatabaseService = Depends(get_db), user: dict = Depends(get_current_user)):
     """Delete a session"""
     db.delete("sessions", session_id)
     return {"message": "Session deleted"}
 
 # Health check
-@app.get("/health")
+@router.get("/health")
 def health_check():
     return {"status": "healthy", "service": "user-service"}
 
 
-@app.post("/agents", response_model=Agent, status_code=201)
+@router.post("/agents", response_model=Agent, status_code=201)
 async def create_agent(
     request: CreateAgentRequest,
     req: Request,
@@ -450,7 +451,7 @@ async def create_agent(
     )
     return agent
 
-@app.get("/agents", response_model=List[Agent])
+@router.get("/agents", response_model=List[Agent])
 async def list_agents(
     req: Request,
     db: DatabaseService = Depends(get_db),
@@ -462,13 +463,13 @@ async def list_agents(
     logger.log("INFO", "user_action", "Listed all agents.", metadata={"request": get_sanitized_request_data(req)})
     return [Agent(**doc) for doc in all_docs]
 
-@app.get("/agents/{agent_id}", response_model=Agent)
+@router.get("/agents/{agent_id}", response_model=Agent)
 async def get_agent(agent_id: str, db: DatabaseService = Depends(get_db), user: dict = Depends(get_current_user)):
     """Retrieves a specific agent by its ID."""
     agent_doc = db.get("agents", agent_id)
     return Agent(**agent_doc)
 
-@app.delete("/agents/{agent_id}", status_code=204)
+@router.delete("/agents/{agent_id}", status_code=204)
 async def delete_agent(
     agent_id: str, 
     req: Request,
@@ -485,7 +486,7 @@ async def delete_agent(
         raise e
 
 
-@app.post("/mcp/tools")
+@router.post("/mcp/tools")
 async def list_mcp_tools(
     request: ListMcpToolsRequest,
     mcp_service: McpClientService = Depends(get_mcp_client_service),
@@ -495,14 +496,14 @@ async def list_mcp_tools(
     tools = await mcp_service.list_tools_for_server(request.mcp_url, request.auth_token)
     return {"mcp_url": request.mcp_url, "tools": tools}
 
-@app.post("/agents/generate-code", response_model=GenerateCodeResponse)
+@router.post("/agents/generate-code", response_model=GenerateCodeResponse)
 async def generate_agent_code(request: GenerateCodeRequest, user: dict = Depends(get_current_user)):
     """Generates agent code based on the provided configuration."""
     from agent_factory import generate_agent_code as generate_code_function
     code = await generate_code_function(request)
     return code
 
-@app.post("/specs/fetch")
+@router.post("/specs/fetch")
 async def fetch_spec_from_url(request: FetchSpecRequest, user: dict = Depends(get_current_user)):
     """Fetches OpenAPI/Swagger spec content from a public URL."""
     async with httpx.AsyncClient() as client:
@@ -532,7 +533,7 @@ async def fetch_spec_from_url(request: FetchSpecRequest, user: dict = Depends(ge
             raise HTTPException(status_code=400, detail=f"Error fetching from URL: {e}")
 
 
-@app.post("/agents/{agent_id}/deploy", status_code=201)
+@router.post("/agents/{agent_id}/deploy", status_code=201)
 async def deploy_agent(agent_id: str, db: DatabaseService = Depends(get_db), user: dict = Depends(get_current_user)):
     """Registers an agent for internal REST deployment."""
     agent_doc = db.get("agents", agent_id)
@@ -560,7 +561,7 @@ async def deploy_agent(agent_id: str, db: DatabaseService = Depends(get_db), use
         else:
             raise e
 
-@app.delete("/agents/{agent_id}/undeploy", status_code=204)
+@router.delete("/agents/{agent_id}/undeploy", status_code=204)
 async def undeploy_agent(agent_id: str, db: DatabaseService = Depends(get_db), user: dict = Depends(get_current_user)):
     """Removes an agent from the internal REST deployment registry."""
     agent_doc = db.get("agents", agent_id)
@@ -580,7 +581,7 @@ async def undeploy_agent(agent_id: str, db: DatabaseService = Depends(get_db), u
             raise e # Re-raise other errors
     return
 
-@app.get("/agents/{agent_id}/deployment")
+@router.get("/agents/{agent_id}/deployment")
 async def get_agent_deployment(agent_id: str, db: DatabaseService = Depends(get_db), user: dict = Depends(get_current_user)):
     """Checks if an agent is deployed and returns its public-facing name."""
     agent_doc = db.get("agents", agent_id)
@@ -603,7 +604,7 @@ async def get_agent_deployment(agent_id: str, db: DatabaseService = Depends(get_
             return {"is_deployed": False}
         raise e
 
-@app.get("/deployments", response_model=List[DeployedApi])
+@router.get("/deployments", response_model=List[DeployedApi])
 async def list_deployments(db: DatabaseService = Depends(get_db), user: dict = Depends(get_current_user)):
     """Lists all deployed agents/APIs with their relevant details."""
     try:
@@ -680,7 +681,7 @@ async def _execute_agent_code(code: str, input_dict: dict, tools: dict, gofannon
     result = await run_function(input_dict=input_dict, tools=tools)
     return result
 
-@app.post("/agents/run-code", response_model=RunCodeResponse)
+@router.post("/agents/run-code", response_model=RunCodeResponse)
 async def run_agent_code(
     request: RunCodeRequest,
     req: Request,
@@ -715,7 +716,7 @@ async def run_agent_code(
         # We re-raise it here so that middleware can do its job.
         raise e
 
-@app.post("/rest/{friendly_name}")
+@router.post("/rest/{friendly_name}")
 async def run_deployed_agent(friendly_name: str, request: Request, db: DatabaseService = Depends(get_db)):
     """Public endpoint to run a deployed agent by its friendly_name."""
     try:
@@ -747,7 +748,7 @@ async def run_deployed_agent(friendly_name: str, request: Request, db: DatabaseS
 
 # --- Demo App Endpoints ---
 
-@app.post("/demos/generate-code", response_model=GenerateDemoCodeResponse)
+@router.post("/demos/generate-code", response_model=GenerateDemoCodeResponse)
 async def generate_demo_app_code(request: GenerateDemoCodeRequest, user: dict = Depends(get_current_user)):
     """
     Generates HTML/CSS/JS for a demo app based on a prompt and selected APIs.
@@ -759,7 +760,7 @@ async def generate_demo_app_code(request: GenerateDemoCodeRequest, user: dict = 
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Error generating demo code: {e}")
 
-@app.post("/demos", response_model=DemoApp, status_code=201)
+@router.post("/demos", response_model=DemoApp, status_code=201)
 async def create_demo_app(request: CreateDemoAppRequest, db: DatabaseService = Depends(get_db), user: dict = Depends(get_current_user)):
     """Saves a new demo app configuration."""
     demo_app_data = request.model_dump(by_alias=True)
@@ -769,19 +770,19 @@ async def create_demo_app(request: CreateDemoAppRequest, db: DatabaseService = D
     demo_app.rev = saved_doc.get("rev")
     return demo_app
 
-@app.get("/demos", response_model=List[DemoApp])
+@router.get("/demos", response_model=List[DemoApp])
 async def list_demo_apps(db: DatabaseService = Depends(get_db), user: dict = Depends(get_current_user)):
     """Lists all saved demo apps."""
     all_docs = db.list_all("demos")
     return [DemoApp(**doc) for doc in all_docs]
 
-@app.get("/demos/{demo_id}", response_model=DemoApp)
+@router.get("/demos/{demo_id}", response_model=DemoApp)
 async def get_demo_app(demo_id: str, db: DatabaseService = Depends(get_db), user: dict = Depends(get_current_user)):
     """Retrieves a specific demo app."""
     doc = db.get("demos", demo_id)
     return DemoApp(**doc)
 
-@app.put("/demos/{demo_id}", response_model=DemoApp)
+@router.put("/demos/{demo_id}", response_model=DemoApp)
 async def update_demo_app(demo_id: str, request: CreateDemoAppRequest, db: DatabaseService = Depends(get_db), user: dict = Depends(get_current_user)):
     """Updates an existing demo app."""
     demo_app_data = request.model_dump(by_alias=True)
@@ -791,11 +792,25 @@ async def update_demo_app(demo_id: str, request: CreateDemoAppRequest, db: Datab
     updated_model.rev = saved_doc.get("rev")
     return updated_model
 
-@app.delete("/demos/{demo_id}", status_code=204)
+@router.delete("/demos/{demo_id}", status_code=204)
 async def delete_demo_app(demo_id: str, db: DatabaseService = Depends(get_db), user: dict = Depends(get_current_user)):
     """Deletes a demo app."""
     db.delete("demos", demo_id)
-    return 
+    return
+
+def register_builtin_routes(app_instance: FastAPI):
+    app_instance.include_router(router)
+
+
+def apply_route_registrars(app_instance: FastAPI):
+    for registrar in load_route_registrars():
+        try:
+            registrar(app_instance)
+        except Exception as error:  # pragma: no cover - defensive guard
+            print(f"Failed to apply route registrar {registrar}: {error}")
+
+
+apply_route_registrars(app)
 
 # This is an unseemly hack to adapt FastAPI to Google Cloud Functions.
 # TODO refactor all of this into microservices.

--- a/webapp/packages/webui/src/App.jsx
+++ b/webapp/packages/webui/src/App.jsx
@@ -1,35 +1,16 @@
-import React, { useContext, useEffect } from 'react';
-import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
+import React, { useContext, useEffect, useMemo } from 'react';
+import { BrowserRouter as Router, Routes, Route, Navigate, Outlet } from 'react-router-dom';
 import config from './config';
 import { AuthContext } from './contexts/AuthContext';
-import { AgentCreationFlowProvider } from './pages/AgentCreationFlow/AgentCreationFlowContext';
-import { DemoCreationFlowProvider } from './pages/DemoCreationFlow/DemoCreationFlowContext';
 import { useLocation } from 'react-router-dom';
 import ErrorBoundary from './components/ErrorBoundary';
 import observabilityService from './services/observabilityService';
 import Layout from './components/Layout';
-import LoginPage from './pages/LoginPage';
-import HomePage from './pages/HomePage';
-import ChatPage from './pages/ChatPage';
-import ViewAgent from './pages/ViewAgent';
-import SavedAgentsPage from './pages/SavedAgentsPage';
-import DeployedApisPage from './pages/DeployedApisPage';
-import DemoAppsPage from './pages/DemoAppsPage';
-import ViewDemoAppPage from './pages/ViewDemoAppPage';
-import ToolsScreen from './pages/AgentCreationFlow/ToolsScreen'; 
-import DescriptionScreen from './pages/AgentCreationFlow/DescriptionScreen';
-import SchemasScreen from './pages/AgentCreationFlow/SchemasScreen';
-import SandboxScreen from './pages/AgentCreationFlow/SandboxScreen';
-import DeployScreen from './pages/AgentCreationFlow/DeployScreen';
-import SaveAgentScreen from './pages/AgentCreationFlow/SaveAgentScreen';
 import CircularProgress from '@mui/material/CircularProgress';
 import Box from '@mui/material/Box';
 
 
-import SelectApisScreen from './pages/DemoCreationFlow/SelectApisScreen';
-import SelectModelScreen from './pages/DemoCreationFlow/SelectModelScreen';
-import CanvasScreen from './pages/DemoCreationFlow/CanvasScreen';
-import SaveDemoScreen from './pages/DemoCreationFlow/SaveDemoScreen';
+import loadRoutesConfig from './config/routes/loadRoutesConfig';
 
 const RouteChangeTracker = () => {
   const location = useLocation();
@@ -61,137 +42,47 @@ function PrivateRoute({ children }) {
   return user ? children : <Navigate to="/login" />;
 }
 
+const wrapWithProviders = (element, providers = []) =>
+  (providers || []).reduceRight((child, Provider) => <Provider>{child}</Provider>, element);
+
+const buildRouteElement = (route) => {
+  const baseElement =
+    route.element ?? (route.children?.length ? <Outlet /> : <React.Fragment />);
+  const wrappedContent = wrapWithProviders(baseElement, route.providers);
+  const useLayout = route.useLayout ?? true;
+  const withLayout = useLayout ? <Layout>{wrappedContent}</Layout> : wrappedContent;
+  const requiresAuth = route.requiresAuth ?? true;
+
+  return requiresAuth ? <PrivateRoute>{withLayout}</PrivateRoute> : withLayout;
+};
+
+const renderRoute = (route) => {
+  const element = buildRouteElement(route);
+  const children = route.children?.map((child) => renderRoute(child));
+  const key = route.id || route.path || route.index;
+
+  if (route.index) {
+    return <Route key={key} index element={element} />;
+  }
+
+  return (
+    <Route key={key} path={route.path} element={element}>
+      {children}
+    </Route>
+  );
+};
+
 function App() {
+  const routesConfig = useMemo(() => loadRoutesConfig(), []);
   useEffect(() => {
     document.title = config?.app?.name || 'Gofannon: Web UI';
-  }, []);  
+  }, []);
   return (
     <ErrorBoundary>
-    <Router>
-      <RouteChangeTracker />
-      <Routes>
-        <Route path="/login" element={<LoginPage />} />
-        <Route
-          path="/"
-          element={
-            <PrivateRoute>
-              <Layout>
-                <HomePage />
-              </Layout>
-            </PrivateRoute>
-          }
-        />
-        <Route
-          path="/agents"
-          element={
-            <PrivateRoute>
-              <Layout>
-                <SavedAgentsPage />
-              </Layout>
-            </PrivateRoute>
-          }
-        />
-        <Route
-          path="/deployed-apis"
-          element={
-            <PrivateRoute>
-              <Layout>
-                <DeployedApisPage />
-              </Layout>
-            </PrivateRoute>
-          }
-        />
-        <Route
-          path="/demo-apps"
-          element={
-            <PrivateRoute>
-              <Layout>
-                <DemoAppsPage />
-              </Layout>
-            </PrivateRoute>
-          }
-        />
-        <Route
-          path="/demos/:demoId"
-          element={<PrivateRoute><ViewDemoAppPage /></PrivateRoute>} // This page renders the app, no layout
-        />
-        <Route
-          path="/chat"
-          element={
-            <PrivateRoute>
-              <Layout>
-                <ChatPage />
-              </Layout>
-            </PrivateRoute>
-          }
-        />
-        <Route
-          path="/agent/:agentId"
-          element={
-            <PrivateRoute>
-              <Layout>
-                {/* Provider is needed for navigation to sandbox/deploy */}
-                <AgentCreationFlowProvider>
-                  <ViewAgent />
-                </AgentCreationFlowProvider>
-              </Layout>
-            </PrivateRoute>
-          }
-        />
-        <Route
-          path="/agent/:agentId/deploy"
-          element={
-            <PrivateRoute>
-              <Layout>
-                <AgentCreationFlowProvider>
-                  <DeployScreen />
-                </AgentCreationFlowProvider>
-              </Layout>
-            </PrivateRoute>
-          }
-        />
-        <Route 
-          path="/create-agent/*" 
-          element={
-            <PrivateRoute>
-              <Layout>
-                <AgentCreationFlowProvider>
-                  <Routes>
-                    <Route index element={<Navigate to="tools" replace />} /> {/* Default to tools screen */}
-                    <Route path="tools" element={<ToolsScreen />} />
-                    <Route path="description" element={<DescriptionScreen />} />
-                    <Route path="schemas" element={<SchemasScreen />} />
-                    <Route path="code" element={<ViewAgent isCreating={true} />} />
-                    <Route path="sandbox" element={<SandboxScreen />} />
-                    <Route path="deploy" element={<DeployScreen />} />
-                    <Route path="save" element={<SaveAgentScreen />} />
-                  </Routes>
-                </AgentCreationFlowProvider>
-              </Layout>
-            </PrivateRoute>
-          }
-        />
-        <Route
-          path="/create-demo/*"
-          element={
-            <PrivateRoute>
-              <Layout>
-                <DemoCreationFlowProvider>
-                  <Routes>
-                    <Route index element={<Navigate to="select-apis" replace />} />
-                    <Route path="select-apis" element={<SelectApisScreen />} />
-                    <Route path="select-model" element={<SelectModelScreen />} />
-                    <Route path="canvas" element={<CanvasScreen />} />
-                    <Route path="save" element={<SaveDemoScreen />} />
-                  </Routes>
-                </DemoCreationFlowProvider>
-              </Layout>
-            </PrivateRoute>
-          }
-        />        
-      </Routes>
-
-    </Router>
+      <Router>
+        <RouteChangeTracker />
+        <Routes>{routesConfig.routes.map((route) => renderRoute(route))}</Routes>
+      </Router>
     </ErrorBoundary>
   );
 }

--- a/webapp/packages/webui/src/config/routes/defaultRoutes.js
+++ b/webapp/packages/webui/src/config/routes/defaultRoutes.js
@@ -1,0 +1,117 @@
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+import LoginPage from '../../pages/LoginPage';
+import HomePage from '../../pages/HomePage';
+import ChatPage from '../../pages/ChatPage';
+import ViewAgent from '../../pages/ViewAgent';
+import SavedAgentsPage from '../../pages/SavedAgentsPage';
+import DeployedApisPage from '../../pages/DeployedApisPage';
+import DemoAppsPage from '../../pages/DemoAppsPage';
+import ViewDemoAppPage from '../../pages/ViewDemoAppPage';
+import ToolsScreen from '../../pages/AgentCreationFlow/ToolsScreen';
+import DescriptionScreen from '../../pages/AgentCreationFlow/DescriptionScreen';
+import SchemasScreen from '../../pages/AgentCreationFlow/SchemasScreen';
+import SandboxScreen from '../../pages/AgentCreationFlow/SandboxScreen';
+import DeployScreen from '../../pages/AgentCreationFlow/DeployScreen';
+import SaveAgentScreen from '../../pages/AgentCreationFlow/SaveAgentScreen';
+import SelectApisScreen from '../../pages/DemoCreationFlow/SelectApisScreen';
+import SelectModelScreen from '../../pages/DemoCreationFlow/SelectModelScreen';
+import CanvasScreen from '../../pages/DemoCreationFlow/CanvasScreen';
+import SaveDemoScreen from '../../pages/DemoCreationFlow/SaveDemoScreen';
+import { AgentCreationFlowProvider } from '../../pages/AgentCreationFlow/AgentCreationFlowContext';
+import { DemoCreationFlowProvider } from '../../pages/DemoCreationFlow/DemoCreationFlowContext';
+
+const defaultRoutesConfig = {
+  routes: [
+    {
+      id: 'login',
+      path: '/login',
+      element: <LoginPage />,
+      requiresAuth: false,
+      useLayout: false,
+    },
+    {
+      id: 'home',
+      path: '/',
+      element: <HomePage />,
+      useLayout: true,
+    },
+    {
+      id: 'saved-agents',
+      path: '/agents',
+      element: <SavedAgentsPage />,
+      useLayout: true,
+    },
+    {
+      id: 'deployed-apis',
+      path: '/deployed-apis',
+      element: <DeployedApisPage />,
+      useLayout: true,
+    },
+    {
+      id: 'demo-apps',
+      path: '/demo-apps',
+      element: <DemoAppsPage />,
+      useLayout: true,
+    },
+    {
+      id: 'view-demo',
+      path: '/demos/:demoId',
+      element: <ViewDemoAppPage />,
+      useLayout: false,
+    },
+    {
+      id: 'chat',
+      path: '/chat',
+      element: <ChatPage />,
+      useLayout: true,
+    },
+    {
+      id: 'view-agent',
+      path: '/agent/:agentId',
+      element: <ViewAgent />,
+      useLayout: true,
+      providers: [AgentCreationFlowProvider],
+    },
+    {
+      id: 'deploy-agent',
+      path: '/agent/:agentId/deploy',
+      element: <DeployScreen />,
+      useLayout: true,
+      providers: [AgentCreationFlowProvider],
+    },
+    {
+      id: 'create-agent-flow',
+      path: '/create-agent/*',
+      element: null,
+      useLayout: true,
+      providers: [AgentCreationFlowProvider],
+      children: [
+        { id: 'create-agent-default', index: true, element: <Navigate to="tools" replace /> },
+        { id: 'create-agent-tools', path: 'tools', element: <ToolsScreen /> },
+        { id: 'create-agent-description', path: 'description', element: <DescriptionScreen /> },
+        { id: 'create-agent-schemas', path: 'schemas', element: <SchemasScreen /> },
+        { id: 'create-agent-code', path: 'code', element: <ViewAgent isCreating={true} /> },
+        { id: 'create-agent-sandbox', path: 'sandbox', element: <SandboxScreen /> },
+        { id: 'create-agent-deploy', path: 'deploy', element: <DeployScreen /> },
+        { id: 'create-agent-save', path: 'save', element: <SaveAgentScreen /> },
+      ],
+    },
+    {
+      id: 'create-demo-flow',
+      path: '/create-demo/*',
+      element: null,
+      useLayout: true,
+      providers: [DemoCreationFlowProvider],
+      children: [
+        { id: 'create-demo-default', index: true, element: <Navigate to="select-apis" replace /> },
+        { id: 'create-demo-select-apis', path: 'select-apis', element: <SelectApisScreen /> },
+        { id: 'create-demo-select-model', path: 'select-model', element: <SelectModelScreen /> },
+        { id: 'create-demo-canvas', path: 'canvas', element: <CanvasScreen /> },
+        { id: 'create-demo-save', path: 'save', element: <SaveDemoScreen /> },
+      ],
+    },
+  ],
+};
+
+export default defaultRoutesConfig;

--- a/webapp/packages/webui/src/config/routes/loadRoutesConfig.js
+++ b/webapp/packages/webui/src/config/routes/loadRoutesConfig.js
@@ -1,0 +1,41 @@
+import defaultRoutesConfig from './defaultRoutes';
+import overrideRoutesConfig from './overrides';
+
+const normalizeRoutes = (config) => ({
+  routes: Array.isArray(config?.routes) ? config.routes : [],
+});
+
+const mergeRouteEntry = (baseRoute = {}, overrideRoute = {}) => ({
+  ...baseRoute,
+  ...overrideRoute,
+  children: mergeRoutesList(baseRoute.children, overrideRoute.children),
+});
+
+export const mergeRoutesList = (baseRoutes = [], overrideRoutes = []) => {
+  const base = Array.isArray(baseRoutes) ? baseRoutes : [];
+  const override = Array.isArray(overrideRoutes) ? overrideRoutes : [];
+
+  const mergedMap = new Map(
+    base.map((route, index) => [route.id || route.path || `base-${index}`, { ...route }]),
+  );
+
+  override.forEach((route) => {
+    if (!route?.id && !route?.path) return;
+    const key = route.id || route.path;
+    const current = mergedMap.get(key) || {};
+    mergedMap.set(key, mergeRouteEntry(current, route));
+  });
+
+  return Array.from(mergedMap.values());
+};
+
+export const mergeRoutesConfig = (baseConfig, overrideConfig) => {
+  const base = normalizeRoutes(baseConfig);
+  const override = normalizeRoutes(overrideConfig);
+
+  return { routes: mergeRoutesList(base.routes, override.routes) };
+};
+
+export const loadRoutesConfig = () => mergeRoutesConfig(defaultRoutesConfig, overrideRoutesConfig);
+
+export default loadRoutesConfig;

--- a/webapp/packages/webui/src/config/routes/overrides.js
+++ b/webapp/packages/webui/src/config/routes/overrides.js
@@ -1,0 +1,7 @@
+// External repositories can replace or extend this configuration when copying the webapp.
+// By default no overrides are applied.
+const overrideRoutesConfig = {
+  routes: [],
+};
+
+export default overrideRoutesConfig;

--- a/webapp/packages/webui/src/extensions/index.js
+++ b/webapp/packages/webui/src/extensions/index.js
@@ -1,0 +1,8 @@
+// This file is intentionally minimal. External repositories can modify it to
+// register additional cards, pages, or other client-side extensions when they
+// copy the `webapp` directory.
+
+// Example placeholder (kept commented to avoid side effects in the base build):
+// import { registerExternalCardRegistrar } from './cards/cardRegistry';
+// import EchoCard from './cards/EchoCard';
+// registerExternalCardRegistrar(({ registerCard }) => registerCard(EchoCard));

--- a/webapp/packages/webui/src/main.jsx
+++ b/webapp/packages/webui/src/main.jsx
@@ -6,6 +6,7 @@ import App from './App';
 import theme from './theme';
 import { AuthProvider } from './contexts/AuthContext';
 import { ConfigProvider } from './contexts/ConfigContext';
+import './extensions';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>


### PR DESCRIPTION
## Summary
- load web UI routes from configuration and expose an extension entry point for custom cards and pages
- add configurable FastAPI route registrars so external repositories can attach endpoints
- document an example Echo extension showing how to wire the UI card, page, and API endpoint

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ba0aa650883239350e4c62ac031f9)