### PR TITLE
typo docker-compose -> 'docker compose'

### DIFF
--- a/.github/workflows/nightly-integration-tests.yml
+++ b/.github/workflows/nightly-integration-tests.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Start services with Docker Compose
         working-directory: ./webapp/infra/docker
-        run: docker-compose up -d --build
+        run: docker compose up -d --build
 
       - name: Wait for services to be healthy
         run: |
@@ -98,18 +98,18 @@ jobs:
         working-directory: ./webapp/infra/docker
         run: |
           echo "=== API Logs ==="
-          docker-compose logs api
+          docker compose logs api
           echo "=== WebUI Logs ==="
-          docker-compose logs webui
+          docker compose logs webui
           echo "=== CouchDB Logs ==="
-          docker-compose logs couchdb
+          docker compose logs couchdb
           echo "=== MinIO Logs ==="
-          docker-compose logs minio
+          docker compose logs minio
 
       - name: Stop services
         if: always()
         working-directory: ./webapp/infra/docker
-        run: docker-compose down -v
+        run: docker compose down -v
 
   e2e-tests:
     name: End-to-End Tests
@@ -162,7 +162,7 @@ jobs:
 
       - name: Start services with Docker Compose
         working-directory: ./webapp/infra/docker
-        run: docker-compose up -d --build
+        run: docker compose up -d --build
 
       - name: Wait for services to be healthy
         run: |
@@ -194,14 +194,14 @@ jobs:
         working-directory: ./webapp/infra/docker
         run: |
           echo "=== API Logs ==="
-          docker-compose logs api
+          docker compose logs api
           echo "=== WebUI Logs ==="
-          docker-compose logs webui
+          docker compose logs webui
 
       - name: Stop services
         if: always()
         working-directory: ./webapp/infra/docker
-        run: docker-compose down -v
+        run: docker compose down -v
 
   notify-on-failure:
     name: Notify on Failure

--- a/.github/workflows/webapp-tests.yml
+++ b/.github/workflows/webapp-tests.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Start services with Docker Compose
         working-directory: ./webapp/infra/docker
-        run: docker-compose up -d --build
+        run: docker compose up -d --build
 
       - name: Wait for services to be healthy
         run: |
@@ -80,4 +80,4 @@ jobs:
       - name: Stop services
         if: always()
         working-directory: ./webapp/infra/docker
-        run: docker-compose down
+        run: docker compose down


### PR DESCRIPTION
## Summary
- Switch GitHub Actions workflows to use `docker compose` instead of `docker-compose` to fix missing command on runners.

## Testing
- Integration tests work locally. Should work in git action now.

Fixes #497 