### PR TITLE
LLM setting passthrough fixes #540

### DIFF
--- a/webapp/packages/api/user-service/models/agent.py
+++ b/webapp/packages/api/user-service/models/agent.py
@@ -85,12 +85,19 @@ class Agent(CreateAgentRequest):
 
     # model_config = ConfigDict(populate_by_name=True) # model_config is inherited from CreateAgentRequest
         
+class LlmSettings(BaseModel):
+    """LLM settings passed from the UI to control model behavior in agent sandbox."""
+    max_tokens: Optional[int] = Field(None, alias="maxTokens")
+    temperature: Optional[float] = None
+    reasoning_effort: Optional[str] = Field(None, alias="reasoningEffort")
+    model_config = ConfigDict(populate_by_name=True)
 
 class RunCodeRequest(BaseModel):
     code: str
     input_dict: Dict[str, Any] = Field(..., alias="inputDict")
     tools: Dict[str, List[str]]
     gofannon_agents: Optional[List[str]] = Field(default=[], alias="gofannonAgents")
+    llm_settings: Optional[LlmSettings] = Field(default=None, alias="llmSettings")
     model_config = ConfigDict(populate_by_name=True)
 
 class RunCodeResponse(BaseModel):

--- a/webapp/packages/api/user-service/routes.py
+++ b/webapp/packages/api/user-service/routes.py
@@ -576,6 +576,7 @@ async def run_agent_code(
             tools=request.tools,
             gofannon_agents=request.gofannon_agents,
             db=db,
+            llm_settings=request.llm_settings,
             user_id=user.get("uid"),
             user_basic_info=user_basic_info,
         )

--- a/webapp/packages/api/user-service/tests/unit/test_dependencies.py
+++ b/webapp/packages/api/user-service/tests/unit/test_dependencies.py
@@ -183,7 +183,7 @@ async def test_process_chat_gofannon_flow(monkeypatch):
 
     fake_logger = FakeLogger()
 
-    async def fake_execute_agent_code(*, code, input_dict, tools, gofannon_agents, db, user_id=None, user_basic_info=None):
+    async def fake_execute_agent_code(*, code, input_dict, tools, gofannon_agents, db, user_id=None, user_basic_info=None, llm_settings=None):
         return {"outputText": f"agent:{input_dict['inputText']}"}
 
     monkeypatch.setattr(dependencies_module, "get_database_service", lambda _settings: db_service)

--- a/webapp/packages/webui/src/pages/AgentCreationFlow/SandboxScreen.jsx
+++ b/webapp/packages/webui/src/pages/AgentCreationFlow/SandboxScreen.jsx
@@ -99,7 +99,15 @@ const SandboxScreen = () => {
     observabilityService.log({ eventType: 'user-action', message: 'User running agent in sandbox.' });
 
     try {
-      const response = await agentService.runCodeInSandbox(generatedCode, formData, tools, gofannonAgents);
+      // Extract LLM settings from agent's invokable models
+      const invokableModel = agentData?.invokableModels?.[0] || agentFlowContext.invokableModels?.[0];
+      const llmSettings = invokableModel?.parameters ? {
+        maxTokens: invokableModel.parameters.max_tokens || invokableModel.parameters.maxTokens,
+        temperature: invokableModel.parameters.temperature,
+        reasoningEffort: invokableModel.parameters.reasoning_effort || invokableModel.parameters.reasoningEffort,
+      } : undefined;
+
+      const response = await agentService.runCodeInSandbox(generatedCode, formData, tools, gofannonAgents, llmSettings);
       if (response.error) {
         setError(response.error);
       } else {

--- a/webapp/packages/webui/src/services/agentService.js
+++ b/webapp/packages/webui/src/services/agentService.js
@@ -69,13 +69,14 @@ class AgentService {
       throw error;
     }
   }
-  async runCodeInSandbox(code, inputDict, tools, gofannonAgents) {
+  async runCodeInSandbox(code, inputDict, tools, gofannonAgents, llmSettings) {
     
     const requestBody = {
       code,
       inputDict,
       tools,
       gofannonAgents: (gofannonAgents || []).map(agent => agent.id),
+      llmSettings,
     };
 
     try {


### PR DESCRIPTION
## Summary
Add infrastructure to pass LLM settings (max_tokens, temperature, reasoning_effort) from agent configuration through to the sandbox execution environment. This enables extended thinking and other model-specific parameters to flow from the UI to the LLM calls.

Fixes #540 

## Changes

### Backend

**`models/agent.py`**
- Add `LlmSettings` Pydantic model with fields:
  - `max_tokens` (alias: `maxTokens`)
  - `temperature`
  - `reasoning_effort` (alias: `reasoningEffort`)
- Add `llm_settings` field to `RunCodeRequest`

**`dependencies.py`**
- Add `llm_settings` parameter to `_execute_agent_code()`
- Pass `llm_settings` through to `GofannonClient`
- Apply settings in `call_llm_with_context()` to override parameters
- Unwrap `{"outputText": "..."}` responses from LLM calls

**`routes.py`**
- Wire `llm_settings` from request to `_execute_agent_code()` call in `/agents/run-code` endpoint

**`tests/unit/test_dependencies.py`**
- Add `llm_settings=None` parameter to `fake_execute_agent_code` mock

### Frontend

**`services/agentService.js`**
- Add `llmSettings` parameter to `runCodeInSandbox()` function
- Include `llmSettings` in request body

**`components/AgentCreationFlow/SandboxScreen.jsx`**
- Extract LLM settings from agent's `invokableModels[0].parameters`
- Pass settings to `agentService.runCodeInSandbox()`

## Testing
```bash
# Backend tests
docker exec -e PYTHONPATH=/app docker-api-1 pytest tests/ -v --no-cov

# Frontend tests
cd webapp/packages/webui && pnpm test
```

## Notes
- Settings are extracted from the agent's first invokable model configuration
- No new UI controls needed - settings flow from existing agent configuration

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

### Test Execution

- [x] All existing tests pass locally
- [x] New tests pass locally

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary (particularly complex areas)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have checked that there are no merge conflicts

## Documentation

- [x] No documentation update needed

---

By submitting this PR, I confirm that I have read and agree to follow the project's [Code of Conduct](https://github.com/the-ai-alliance/gofannon/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/the-ai-alliance/gofannon/blob/main/CONTRIBUTING.md).
