### PR TITLE
Anthropic config, fixes #541

### DIFF
--- a/webapp/packages/api/user-service/config/anthropic/__init__.py
+++ b/webapp/packages/api/user-service/config/anthropic/__init__.py
@@ -5,17 +5,21 @@
 models = {
     # =========================================================================
     # Claude 4.5 family (Latest - November 2025)
-    # Note: Cannot specify both temperature and top_p - pick one
+    # - Opus 4.5 supports effort parameter (controls all token usage)
+    # - All support extended thinking via reasoning_effort
     # =========================================================================
     "claude-opus-4-5-20251101": {
-        "returns_thoughts": False,
+        "returns_thoughts": True,
+        "supports_effort": True,
+        "supports_thinking": True,
         "parameters": {
             "temperature": {
                 "type": "float",
                 "default": 1.0,
                 "min": 0.0,
                 "max": 1.0,
-                "description": "Randomness (0=focused, 1=creative)"
+                "description": "Randomness (0=focused, 1=creative). Locked to 1.0 when thinking enabled.",
+                "mutually_exclusive_with": ["top_p"]
             },
             "top_p": {
                 "type": "float",
@@ -25,30 +29,33 @@ models = {
                 "description": "Nucleus sampling (0.1=conservative, 0.95=diverse)",
                 "mutually_exclusive_with": ["temperature"]
             },
+            "max_tokens": {
+                "type": "integer",
+                "default": 16384,
+                "min": 1,
+                "max": 64000,
+                "description": "Maximum tokens in response"
+            },
             "reasoning_effort": {
                 "type": "choice",
                 "default": "disable",
                 "choices": ["disable", "low", "medium", "high"],
-                "description": "Reasoning Effort: Effort level for reasoning during generation"
-            },
-            "max_tokens": {
-                "type": "integer",
-                "default": 8192,
-                "min": 1,
-                "max": 16384,
-                "description": "Maximum tokens in response"
+                "description": "Reasoning Effort: Enables extended thinking and controls effort level"
             },
         }
     },
     "claude-sonnet-4-5-20250929": {
-        "returns_thoughts": False,
+        "returns_thoughts": True,
+        "supports_effort": False,
+        "supports_thinking": True,
         "parameters": {
             "temperature": {
                 "type": "float",
                 "default": 1.0,
                 "min": 0.0,
                 "max": 1.0,
-                "description": "Randomness (0=focused, 1=creative)"
+                "description": "Randomness (0=focused, 1=creative)",
+                "mutually_exclusive_with": ["top_p"]
             },
             "top_p": {
                 "type": "float",
@@ -58,30 +65,33 @@ models = {
                 "description": "Nucleus sampling (0.1=conservative, 0.95=diverse)",
                 "mutually_exclusive_with": ["temperature"]
             },
+            "max_tokens": {
+                "type": "integer",
+                "default": 16384,
+                "min": 1,
+                "max": 64000,
+                "description": "Maximum tokens in response"
+            },
             "reasoning_effort": {
                 "type": "choice",
                 "default": "disable",
                 "choices": ["disable", "low", "medium", "high"],
-                "description": "Reasoning Effort: Effort level for reasoning during generation"
-            },
-            "max_tokens": {
-                "type": "integer",
-                "default": 8192,
-                "min": 1,
-                "max": 16384,
-                "description": "Maximum tokens in response"
+                "description": "Reasoning Effort: Enables extended thinking and controls effort level"
             },
         }
     },
     "claude-haiku-4-5-20251001": {
-        "returns_thoughts": False,
+        "returns_thoughts": True,
+        "supports_effort": False,
+        "supports_thinking": True,
         "parameters": {
             "temperature": {
                 "type": "float",
                 "default": 1.0,
                 "min": 0.0,
                 "max": 1.0,
-                "description": "Randomness (0=focused, 1=creative)"
+                "description": "Randomness (0=focused, 1=creative)",
+                "mutually_exclusive_with": ["top_p"]
             },
             "top_p": {
                 "type": "float",
@@ -91,18 +101,18 @@ models = {
                 "description": "Nucleus sampling (0.1=conservative, 0.95=diverse)",
                 "mutually_exclusive_with": ["temperature"]
             },
+            "max_tokens": {
+                "type": "integer",
+                "default": 16384,
+                "min": 1,
+                "max": 64000,
+                "description": "Maximum tokens in response"
+            },
             "reasoning_effort": {
                 "type": "choice",
                 "default": "disable",
                 "choices": ["disable", "low", "medium", "high"],
-                "description": "Reasoning Effort: Effort level for reasoning during generation"
-            },
-            "max_tokens": {
-                "type": "integer",
-                "default": 8192,
-                "min": 1,
-                "max": 16384,
-                "description": "Maximum tokens in response"
+                "description": "Reasoning Effort: Enables extended thinking and controls effort level"
             },
         }
     },
@@ -111,14 +121,17 @@ models = {
     # Claude 4.1 (August 2025)
     # =========================================================================
     "claude-opus-4-1-20250805": {
-        "returns_thoughts": False,
+        "returns_thoughts": True,
+        "supports_effort": False,
+        "supports_thinking": True,
         "parameters": {
             "temperature": {
                 "type": "float",
                 "default": 1.0,
                 "min": 0.0,
                 "max": 1.0,
-                "description": "Randomness (0=focused, 1=creative)"
+                "description": "Randomness (0=focused, 1=creative)",
+                "mutually_exclusive_with": ["top_p"]
             },
             "top_p": {
                 "type": "float",
@@ -128,18 +141,18 @@ models = {
                 "description": "Nucleus sampling (0.1=conservative, 0.95=diverse)",
                 "mutually_exclusive_with": ["temperature"]
             },
+            "max_tokens": {
+                "type": "integer",
+                "default": 16384,
+                "min": 1,
+                "max": 64000,
+                "description": "Maximum tokens in response"
+            },
             "reasoning_effort": {
                 "type": "choice",
                 "default": "disable",
                 "choices": ["disable", "low", "medium", "high"],
-                "description": "Reasoning Effort: Effort level for reasoning during generation"
-            },
-            "max_tokens": {
-                "type": "integer",
-                "default": 8192,
-                "min": 1,
-                "max": 16384,
-                "description": "Maximum tokens in response"
+                "description": "Reasoning Effort: Enables extended thinking and controls effort level"
             },
         }
     },
@@ -148,14 +161,17 @@ models = {
     # Claude 4 (May 2025)
     # =========================================================================
     "claude-opus-4-20250514": {
-        "returns_thoughts": False,
+        "returns_thoughts": True,
+        "supports_effort": False,
+        "supports_thinking": True,
         "parameters": {
             "temperature": {
                 "type": "float",
                 "default": 1.0,
                 "min": 0.0,
                 "max": 1.0,
-                "description": "Randomness (0=focused, 1=creative)"
+                "description": "Randomness (0=focused, 1=creative)",
+                "mutually_exclusive_with": ["top_p"]
             },
             "top_p": {
                 "type": "float",
@@ -165,30 +181,33 @@ models = {
                 "description": "Nucleus sampling (0.1=conservative, 0.95=diverse)",
                 "mutually_exclusive_with": ["temperature"]
             },
+            "max_tokens": {
+                "type": "integer",
+                "default": 16384,
+                "min": 1,
+                "max": 64000,
+                "description": "Maximum tokens in response"
+            },
             "reasoning_effort": {
                 "type": "choice",
                 "default": "disable",
                 "choices": ["disable", "low", "medium", "high"],
-                "description": "Reasoning Effort: Effort level for reasoning during generation"
-            },
-            "max_tokens": {
-                "type": "integer",
-                "default": 8192,
-                "min": 1,
-                "max": 16384,
-                "description": "Maximum tokens in response"
+                "description": "Reasoning Effort: Enables extended thinking and controls effort level"
             },
         }
     },
     "claude-sonnet-4-20250514": {
-        "returns_thoughts": False,
+        "returns_thoughts": True,
+        "supports_effort": False,
+        "supports_thinking": True,
         "parameters": {
             "temperature": {
                 "type": "float",
                 "default": 1.0,
                 "min": 0.0,
                 "max": 1.0,
-                "description": "Randomness (0=focused, 1=creative)"
+                "description": "Randomness (0=focused, 1=creative)",
+                "mutually_exclusive_with": ["top_p"]
             },
             "top_p": {
                 "type": "float",
@@ -198,18 +217,18 @@ models = {
                 "description": "Nucleus sampling (0.1=conservative, 0.95=diverse)",
                 "mutually_exclusive_with": ["temperature"]
             },
+            "max_tokens": {
+                "type": "integer",
+                "default": 16384,
+                "min": 1,
+                "max": 64000,
+                "description": "Maximum tokens in response"
+            },
             "reasoning_effort": {
                 "type": "choice",
                 "default": "disable",
                 "choices": ["disable", "low", "medium", "high"],
-                "description": "Reasoning Effort: Effort level for reasoning during generation"
-            },
-            "max_tokens": {
-                "type": "integer",
-                "default": 8192,
-                "min": 1,
-                "max": 16384,
-                "description": "Maximum tokens in response"
+                "description": "Reasoning Effort: Enables extended thinking and controls effort level"
             },
         }
     },
@@ -218,14 +237,17 @@ models = {
     # Claude 3.7 (February 2025)
     # =========================================================================
     "claude-3-7-sonnet-20250219": {
-        "returns_thoughts": False,
+        "returns_thoughts": True,
+        "supports_effort": False,
+        "supports_thinking": True,
         "parameters": {
             "temperature": {
                 "type": "float",
                 "default": 1.0,
                 "min": 0.0,
                 "max": 1.0,
-                "description": "Randomness (0=focused, 1=creative)"
+                "description": "Randomness (0=focused, 1=creative)",
+                "mutually_exclusive_with": ["top_p"]
             },
             "top_p": {
                 "type": "float",
@@ -235,34 +257,37 @@ models = {
                 "description": "Nucleus sampling (0.1=conservative, 0.95=diverse)",
                 "mutually_exclusive_with": ["temperature"]
             },
+            "max_tokens": {
+                "type": "integer",
+                "default": 16384,
+                "min": 1,
+                "max": 128000,
+                "description": "Maximum tokens in response"
+            },
             "reasoning_effort": {
                 "type": "choice",
                 "default": "disable",
                 "choices": ["disable", "low", "medium", "high"],
-                "description": "Reasoning Effort: Effort level for reasoning during generation"
-            },
-            "max_tokens": {
-                "type": "integer",
-                "default": 8192,
-                "min": 1,
-                "max": 8192,
-                "description": "Maximum tokens in response"
+                "description": "Reasoning Effort: Enables extended thinking and controls effort level"
             },
         }
     },
 
     # =========================================================================
-    # Claude 3.5 family (2024)
+    # Claude 3.5 family (2024) - No extended thinking support
     # =========================================================================
     "claude-3-5-sonnet-20241022": {
         "returns_thoughts": False,
+        "supports_effort": False,
+        "supports_thinking": False,
         "parameters": {
             "temperature": {
                 "type": "float",
                 "default": 1.0,
                 "min": 0.0,
                 "max": 1.0,
-                "description": "Randomness (0=focused, 1=creative)"
+                "description": "Randomness (0=focused, 1=creative)",
+                "mutually_exclusive_with": ["top_p"]
             },
             "top_p": {
                 "type": "float",
@@ -271,12 +296,6 @@ models = {
                 "max": 1.0,
                 "description": "Nucleus sampling (0.1=conservative, 0.95=diverse)",
                 "mutually_exclusive_with": ["temperature"]
-            },
-            "reasoning_effort": {
-                "type": "choice",
-                "default": "disable",
-                "choices": ["disable", "low", "medium", "high"],
-                "description": "Reasoning Effort: Effort level for reasoning during generation"
             },
             "max_tokens": {
                 "type": "integer",
@@ -289,13 +308,16 @@ models = {
     },
     "claude-3-5-sonnet-20240620": {
         "returns_thoughts": False,
+        "supports_effort": False,
+        "supports_thinking": False,
         "parameters": {
             "temperature": {
                 "type": "float",
                 "default": 1.0,
                 "min": 0.0,
                 "max": 1.0,
-                "description": "Randomness (0=focused, 1=creative)"
+                "description": "Randomness (0=focused, 1=creative)",
+                "mutually_exclusive_with": ["top_p"]
             },
             "top_p": {
                 "type": "float",
@@ -304,12 +326,6 @@ models = {
                 "max": 1.0,
                 "description": "Nucleus sampling (0.1=conservative, 0.95=diverse)",
                 "mutually_exclusive_with": ["temperature"]
-            },
-            "reasoning_effort": {
-                "type": "choice",
-                "default": "disable",
-                "choices": ["disable", "low", "medium", "high"],
-                "description": "Reasoning Effort: Effort level for reasoning during generation"
             },
             "max_tokens": {
                 "type": "integer",
@@ -322,13 +338,16 @@ models = {
     },
     "claude-3-5-haiku-20241022": {
         "returns_thoughts": False,
+        "supports_effort": False,
+        "supports_thinking": False,
         "parameters": {
             "temperature": {
                 "type": "float",
                 "default": 1.0,
                 "min": 0.0,
                 "max": 1.0,
-                "description": "Randomness (0=focused, 1=creative)"
+                "description": "Randomness (0=focused, 1=creative)",
+                "mutually_exclusive_with": ["top_p"]
             },
             "top_p": {
                 "type": "float",
@@ -337,12 +356,6 @@ models = {
                 "max": 1.0,
                 "description": "Nucleus sampling (0.1=conservative, 0.95=diverse)",
                 "mutually_exclusive_with": ["temperature"]
-            },
-            "reasoning_effort": {
-                "type": "choice",
-                "default": "disable",
-                "choices": ["disable", "low", "medium", "high"],
-                "description": "Reasoning Effort: Effort level for reasoning during generation"
             },
             "max_tokens": {
                 "type": "integer",
@@ -359,13 +372,16 @@ models = {
     # =========================================================================
     "claude-3-haiku-20240307": {
         "returns_thoughts": False,
+        "supports_effort": False,
+        "supports_thinking": False,
         "parameters": {
             "temperature": {
                 "type": "float",
                 "default": 1.0,
                 "min": 0.0,
                 "max": 1.0,
-                "description": "Randomness (0=focused, 1=creative)"
+                "description": "Randomness (0=focused, 1=creative)",
+                "mutually_exclusive_with": ["top_p"]
             },
             "top_p": {
                 "type": "float",
@@ -374,12 +390,6 @@ models = {
                 "max": 1.0,
                 "description": "Nucleus sampling (0.1=conservative, 0.95=diverse)",
                 "mutually_exclusive_with": ["temperature"]
-            },
-            "reasoning_effort": {
-                "type": "choice",
-                "default": "disable",
-                "choices": ["disable", "low", "medium", "high"],
-                "description": "Reasoning Effort: Effort level for reasoning during generation"
             },
             "max_tokens": {
                 "type": "integer",


### PR DESCRIPTION
Fixes #541 
<html><head></head><body><h1>PR: Update Anthropic Model Configurations</h1>
<h2>Summary</h2>
<p>Updates <code>config/anthropic/__init__.py</code> with correct max_tokens limits, thinking support flags, and parameter constraints based on current Anthropic API documentation.</p>
<h2>Changes</h2>
<h3>Model Configuration Updates</h3>

Model Family | max_tokens | supports_thinking | supports_effort | returns_thoughts
-- | -- | -- | -- | --
Claude 4.5 (Opus, Sonnet, Haiku) | 64,000 | ✓ | Opus only | ✓
Claude 4.1 | 64,000 | ✓ | ✗ | ✓
Claude 4 | 64,000 | ✓ | ✗ | ✓
Claude 3.7 Sonnet | 128,000 | ✓ | ✗ | ✓
Claude 3.5 family | 8,192 | ✗ | ✗ | ✗
Claude 3 Haiku | 4,096 | ✗ | ✗ | ✗


<h3>Parameter Changes</h3>
<ul>
<li><strong><code>max_tokens</code></strong>: Updated to match actual Anthropic API limits (verified via docs)</li>
<li><strong><code>mutually_exclusive_with</code></strong>: Added to both <code>temperature</code> and <code>top_p</code> parameters (Claude 4.x doesn't allow both)</li>
<li><strong><code>supports_effort</code></strong>: Only <code>True</code> for Claude Opus 4.5 (controls all token usage)</li>
<li><strong><code>returns_thoughts</code></strong>: <code>True</code> for models that support extended thinking (3.7+)</li>
<li><strong><code>reasoning_effort</code></strong>: Only included for models with <code>supports_thinking: True</code></li>
</ul>
<h3>Type Consistency</h3>
<ul>
<li>Using <code>"type": "integer"</code> for <code>max_tokens</code> (consistent with existing codebase)</li>
</ul>
<h2>Files Changed</h2>
<pre><code>config/anthropic/__init__.py
</code></pre>
<h2>Testing</h2>
<p>Run unit tests:</p>
<pre><code class="language-bash">docker exec -e PYTHONPATH=/app docker-api-1 pytest tests/ -v --no-cov
</code></pre>
<p>Expected: All 229 tests passing</p>
<h2>Verification</h2>
<p>Max token limits verified against:</p>
<ul>
<li><a href="https://docs.anthropic.com/en/docs/about-claude/models/overview">Anthropic Model Overview</a></li>
<li><a href="https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-anthropic-claude-messages.html">AWS Bedrock Claude Documentation</a></li>
<li>GitHub issues confirming limits (Claude 4.x = 64K, Claude 3.7 = 128K, Haiku 4.5 = 64K)</li>
</ul>
<h2>Notes</h2>
<ul>
<li>Claude 3.7 Sonnet's 128K output requires beta header for full access</li>
<li>Temperature is locked to 1.0 when extended thinking is enabled</li>
<li><code>supports_effort</code> is a new Opus 4.5 feature that controls total token budget allocation</li>
</ul></body></html># PR: Update Anthropic Model Configurations

## Summary

Updates `config/anthropic/__init__.py` with correct max_tokens limits, thinking support flags, and parameter constraints based on current Anthropic API documentation.

## Changes

### Model Configuration Updates

| Model Family | max_tokens | supports_thinking | supports_effort | returns_thoughts |
|--------------|------------|-------------------|-----------------|------------------|
| Claude 4.5 (Opus, Sonnet, Haiku) | 64,000 | ✓ | Opus only | ✓ |
| Claude 4.1 | 64,000 | ✓ | ✗ | ✓ |
| Claude 4 | 64,000 | ✓ | ✗ | ✓ |
| Claude 3.7 Sonnet | 128,000 | ✓ | ✗ | ✓ |
| Claude 3.5 family | 8,192 | ✗ | ✗ | ✗ |
| Claude 3 Haiku | 4,096 | ✗ | ✗ | ✗ |

### Parameter Changes

- **`max_tokens`**: Updated to match actual Anthropic API limits (verified via docs)
- **`mutually_exclusive_with`**: Added to both `temperature` and `top_p` parameters (Claude 4.x doesn't allow both)
- **`supports_effort`**: Only `True` for Claude Opus 4.5 (controls all token usage)
- **`returns_thoughts`**: `True` for models that support extended thinking (3.7+)
- **`reasoning_effort`**: Only included for models with `supports_thinking: True`

### Type Consistency

- Using `"type": "integer"` for `max_tokens` (consistent with existing codebase)

## Files Changed

```
config/anthropic/__init__.py
```

## Testing

Run unit tests:
```bash
docker exec -e PYTHONPATH=/app docker-api-1 pytest tests/ -v --no-cov
```

Expected: All 229 tests passing

## Verification

Max token limits verified against:
- [[Anthropic Model Overview](https://docs.anthropic.com/en/docs/about-claude/models/overview)](https://docs.anthropic.com/en/docs/about-claude/models/overview)
- [[AWS Bedrock Claude Documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-anthropic-claude-messages.html)](https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-anthropic-claude-messages.html)
- GitHub issues confirming limits (Claude 4.x = 64K, Claude 3.7 = 128K, Haiku 4.5 = 64K)

## Notes

- Claude 3.7 Sonnet's 128K output requires beta header for full access
- Temperature is locked to 1.0 when extended thinking is enabled
- `supports_effort` is a new Opus 4.5 feature that controls total token budget allocation

---

By submitting this PR, I confirm that I have read and agree to follow the project's [Code of Conduct](https://github.com/the-ai-alliance/gofannon/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/the-ai-alliance/gofannon/blob/main/CONTRIBUTING.md).
