### PR TITLE
Fixing docker couch hang; fixes #547

### DIFF
--- a/webapp/infra/docker/Dockerfile.api
+++ b/webapp/infra/docker/Dockerfile.api
@@ -1,4 +1,9 @@
+# webapp/infra/docker/Dockerfile.api
 FROM python:3.10-slim
+
+# curl is needed by the entrypoint to wait for / init CouchDB
+RUN apt-get update && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
@@ -7,7 +12,12 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
+# Add the entrypoint wrapper that handles CouchDB wait + init
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
 EXPOSE 8000
 
-# The command will be provided by docker-compose for local dev
-# For production, you would use: CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+ENTRYPOINT ["/entrypoint.sh"]
+# Default command (overridden by docker-compose for local dev)
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/webapp/infra/docker/docker-compose.yml
+++ b/webapp/infra/docker/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - VITE_APP_ENV=local
     depends_on:
       api:
-        condition: service_started # webui depends on api for data, but api needs couchdb first
+        condition: service_started
     networks:
       - gofannon-net
 
@@ -19,7 +19,7 @@ services:
       context: ../../packages/api/user-service
       dockerfile: ../../../infra/docker/Dockerfile.api
     volumes:
-      - ../../packages/api/user-service:/app # Mount for hot-reloading
+      - ../../packages/api/user-service:/app
     ports:
       - "8000:8000"
     environment:
@@ -30,14 +30,16 @@ services:
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-minioadmin}
       - AWS_DEFAULT_REGION=us-east-1
       - DATABASE_PROVIDER=${DATABASE_PROVIDER:-couchdb}
-      - COUCHDB_URL=${COUCHDB_URL:-http://couchdb:5984/}     
+      - COUCHDB_URL=${COUCHDB_URL:-http://couchdb:5984/}
+      - COUCHDB_USER=${COUCHDB_USER:-admin}
+      - COUCHDB_PASSWORD=${COUCHDB_PASSWORD:-password}
     env_file:
       - ./.env
     depends_on:
+      couchdb:
+        condition: service_healthy
       minio:
         condition: service_started
-      couchdb-setup: 
-        condition: service_completed_successfully
     networks:
       - gofannon-net
     command: uvicorn main:app --host 0.0.0.0 --port 8000 --reload
@@ -45,8 +47,8 @@ services:
   minio:
     image: minio/minio:RELEASE.2023-03-20T20-16-18Z
     ports:
-      - "9000:9000" # API port
-      - "9001:9001" # Console port
+      - "9000:9000"
+      - "9001:9001"
     environment:
       - MINIO_ROOT_USER=minioadmin
       - MINIO_ROOT_PASSWORD=minioadmin
@@ -67,27 +69,12 @@ services:
       - couchdb-data:/opt/couchdb/data
     networks:
       - gofannon-net
-    healthcheck: # <--- ADD THIS HEALTHCHECK
-      test: ["CMD-SHELL", "curl -f http://localhost:5984/ || exit 1"]
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:5984/ || exit 1"]
       interval: 5s
       timeout: 5s
-      retries: 5
-      start_period: 10s # Give CouchDB some time to warm up before checks begin
-
-  couchdb-setup: # <--- NEW SERVICE FOR COUCHDB INITIALIZATION
-    build:
-      context: ../../infra/docker # Use the directory where Dockerfile.couchdb-setup and couchdb-init.sh are
-      dockerfile: Dockerfile.couchdb-setup
-    environment:
-      - COUCHDB_USER=${COUCHDB_USER:-admin}
-      - COUCHDB_PASSWORD=${COUCHDB_PASSWORD:-password}
-      - COUCHDB_URL=http://couchdb:5984/ # Use the internal service name
-    depends_on:
-      couchdb:
-        condition: service_healthy # Wait for couchdb to be healthy before attempting setup
-    networks:
-      - gofannon-net
-    command: /app/couchdb-init.sh # Execute the initialization script
+      retries: 10
+      start_period: 15s
 
 networks:
   gofannon-net:

--- a/webapp/infra/docker/docker-compose.yml
+++ b/webapp/infra/docker/docker-compose.yml
@@ -70,7 +70,7 @@ services:
     networks:
       - gofannon-net
     healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost:5984/ || exit 1"]
+      test: ["CMD-SHELL", "curl -f http://localhost:5984/ || exit 1"]
       interval: 5s
       timeout: 5s
       retries: 10

--- a/webapp/packages/api/user-service/entrypoint.sh
+++ b/webapp/packages/api/user-service/entrypoint.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -e
+
+COUCHDB_URL="${COUCHDB_URL:-http://couchdb:5984}"
+COUCHDB_USER="${COUCHDB_USER:-admin}"
+COUCHDB_PASSWORD="${COUCHDB_PASSWORD:-password}"
+MAX_RETRIES=30
+RETRY_INTERVAL=2
+
+# --- Wait for CouchDB to be reachable ---
+echo "Waiting for CouchDB at ${COUCHDB_URL} ..."
+retries=0
+until curl -sf "${COUCHDB_URL}/" > /dev/null 2>&1; do
+  retries=$((retries + 1))
+  if [ "$retries" -ge "$MAX_RETRIES" ]; then
+    echo "ERROR: CouchDB not available after $((MAX_RETRIES * RETRY_INTERVAL))s — giving up."
+    exit 1
+  fi
+  sleep "$RETRY_INTERVAL"
+done
+echo "CouchDB is up."
+
+# --- One-time initialization (idempotent) ---
+echo "Ensuring _users database exists..."
+response=$(curl -s -o /dev/null -w "%{http_code}" -X PUT \
+  "${COUCHDB_URL}/_users" \
+  -u "${COUCHDB_USER}:${COUCHDB_PASSWORD}" \
+  -H "Content-Type: application/json")
+
+case "$response" in
+  201) echo "_users database created." ;;
+  412) echo "_users database already exists." ;;
+  *)   echo "WARNING: Unexpected status $response creating _users — continuing anyway." ;;
+esac
+
+# Reduce CouchDB log noise
+curl -s -X PUT "${COUCHDB_URL}/_node/nonode@nohost/_config/log/level" \
+  -u "${COUCHDB_USER}:${COUCHDB_PASSWORD}" \
+  -d '"warning"' > /dev/null 2>&1 || true
+
+echo "CouchDB initialization complete."
+
+# --- Hand off to the real command ---
+exec "$@"


### PR DESCRIPTION
# Fix: docker-compose up hangs on fresh code

## Problem

Running `docker-compose up` from scratch would hang indefinitely. The `couchdb-setup` init container created a two-hop dependency chain (`api` → `couchdb-setup completed` → `couchdb healthy`) that blocked the API and everything downstream from starting. The workaround was to manually start CouchDB and MinIO first, wait, then start the remaining services.

## Solution

Eliminated the `couchdb-setup` init container entirely and moved CouchDB initialization into an entrypoint wrapper on the API service.

### Changes

- **Added `entrypoint.sh`** — A shell script that runs before uvicorn. It polls CouchDB with a bounded retry loop (30 retries × 2s = 60s max), creates the `_users` database if needed, sets the log level to `warning`, then `exec`s into the real command. All init operations are idempotent, so repeat runs are safe.
- **Updated `Dockerfile.api`** — Installs `curl` and sets `entrypoint.sh` as the `ENTRYPOINT`. The docker-compose `command:` composes with it normally, so hot-reload still works.
- **Updated `docker-compose.yml`** — The API now depends directly on `couchdb: service_healthy` (one hop instead of two). Healthcheck tuned with `retries: 10` and `start_period: 15s` for cold-start reliability.
- **Removed `couchdb-setup` service**, `Dockerfile.couchdb-setup`, and `couchdb-init.sh`.

## Result

`docker-compose up` works reliably on a clean checkout with no manual intervention.

---

By submitting this PR, I confirm that I have read and agree to follow the project's [Code of Conduct](https://github.com/the-ai-alliance/gofannon/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/the-ai-alliance/gofannon/blob/main/CONTRIBUTING.md).
