### PR TITLE
Adding undeploy; fixes #543

### DIFF
--- a/webapp/packages/api/user-service/routes.py
+++ b/webapp/packages/api/user-service/routes.py
@@ -454,6 +454,9 @@ async def delete_agent(
 ):
     """Deletes an agent by its ID."""
     try:
+        deployment = await get_agent_deployment(agent_id, db)
+        if deployment.get("is_deployed"):
+            await undeploy_agent(agent_id, db)  
         db.delete("agents", agent_id)
         logger.log("INFO", "user_action", f"Agent '{agent_id}' deleted.", metadata={"agent_id": agent_id, "request": get_sanitized_request_data(req)})
         return


### PR DESCRIPTION
# Fix: Clean up deployment record when deleting an agent

Closes #543

## Problem

Deleting an agent from the UI removes it from the `agents` database but leaves its record in the `deployments` database. On subsequent requests, the system iterates deployments, tries to load the now-deleted agent, and logs 404 errors:

```
Skipping deployed agent 'my_agent' due to error: 404: Document '...' not found in 'agents'
```

## Fix

Added a check in the `delete_agent` route to undeploy the agent before deleting it. Both `get_agent_deployment` and `undeploy_agent` were already imported — the route just wasn't using them.

```python
deployment = await get_agent_deployment(agent_id, db)
if deployment.get("is_deployed"):
    await undeploy_agent(agent_id, db)
```

The undeploy must happen first because `undeploy_agent` reads the agent doc to look up its `friendly_name`, which is the key used in the `deployments` database.

---

By submitting this PR, I confirm that I have read and agree to follow the project's [Code of Conduct](https://github.com/the-ai-alliance/gofannon/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/the-ai-alliance/gofannon/blob/main/CONTRIBUTING.md).
