### PR TITLE
Fixing timeouts and handling scale

### DIFF
--- a/webapp/packages/api/user-service/agent_factory/__init__.py
+++ b/webapp/packages/api/user-service/agent_factory/__init__.py
@@ -203,6 +203,7 @@ result = await gofannon_client.call(agent_name='{agent.name}', input_dict={{...}
             tools=None,  # Don't pass tools - we want code generation, not tool execution
             user_id=user_id,
             user_basic_info=user_basic_info,
+            timeout=1800,
         )
 
     # ---- Friendly Name and Docstring Generation Task ----

--- a/webapp/packages/api/user-service/agent_factory/prompts.py
+++ b/webapp/packages/api/user-service/agent_factory/prompts.py
@@ -397,13 +397,36 @@ for i, batch in enumerate(batches):
 final_result, _ = await call_llm(..., f"Consolidate: {{batch_results}}", ...)
 ```
 
-**Always use hierarchical (tree-style) consolidation** that groups results by exact token budget:
+**Always use hierarchical (tree-style) consolidation** that groups results by exact token budget.
+
+**IMPORTANT:** Consolidation is summarization — use lighter parameters to avoid timeouts:
+- **Disable reasoning_effort** for consolidation calls (it's not needed for merging summaries)
+- **Cap max_tokens** at 16384 for consolidation (summaries don't need 128K output)
+- **Set a timeout** to fail fast and fall back to keeping individual results
+
 ```python
 # Hierarchical consolidation — merge groups that fit in the context window
 CONSOLIDATION_TEMPLATE_TOKENS = count_tokens(consolidation_instructions, provider, model)
 MAX_CONSOLIDATION_CONTENT = SAFE_INPUT_LIMIT - CONSOLIDATION_TEMPLATE_TOKENS
 
+# Use lighter parameters for consolidation to avoid timeouts
+consolidation_params = {{**parameters}}
+consolidation_params.pop("reasoning_effort", None)  # Consolidation doesn't need extended thinking
+consolidation_params["max_tokens"] = min(consolidation_params.get("max_tokens", 16384), 16384)
+
+# Timeout for each consolidation call (seconds). Shorter than batch processing
+# since consolidation prompts are smaller and don't need deep reasoning.
+CONSOLIDATION_TIMEOUT = 300  # 5 minutes
+
+# Maximum consolidation rounds to prevent infinite loops
+MAX_CONSOLIDATION_ROUNDS = 5
+
+print(f"Consolidating {{len(batch_results)}} batch results...", flush=True)
+
+consolidation_round = 0
 while len(batch_results) > 1:
+    consolidation_round += 1
+    prev_count = len(batch_results)
     next_level = []
     group = []
     group_tokens = 0
@@ -418,11 +441,13 @@ while len(batch_results) > 1:
                     messages=[{{"role": "user", "content":
                         f"Consolidate these analyses into a unified summary:\\n\\n"
                         + "\\n---\\n".join(group)}}],
-                    parameters=parameters,
+                    parameters=consolidation_params,
+                    timeout=CONSOLIDATION_TIMEOUT,
                 )
                 next_level.append(consolidated)
             except Exception as e:
-                # If consolidation fails, keep the individual results
+                # If consolidation fails (timeout, etc.), keep the individual results
+                print(f"  Consolidation group failed ({{type(e).__name__}}), keeping {{len(group)}} individual results", flush=True)
                 next_level.extend(group)
             group = []
             group_tokens = 0
@@ -441,15 +466,31 @@ while len(batch_results) > 1:
                     messages=[{{"role": "user", "content":
                         f"Consolidate these analyses into a unified summary:\\n\\n"
                         + "\\n---\\n".join(group)}}],
-                    parameters=parameters,
+                    parameters=consolidation_params,
+                    timeout=CONSOLIDATION_TIMEOUT,
                 )
                 next_level.append(consolidated)
             except Exception as e:
+                print(f"  Consolidation group failed ({{type(e).__name__}}), keeping {{len(group)}} individual results", flush=True)
                 next_level.extend(group)
 
+    print(f"  Round {{consolidation_round}}: consolidated {{prev_count}} results into {{len(next_level)}}", flush=True)
     batch_results = next_level
 
-final_result = batch_results[0]
+    # Circuit breaker: if no progress was made (all groups failed), stop looping
+    if len(batch_results) >= prev_count:
+        print(f"  Consolidation made no progress (still {{len(batch_results)}} results). "
+              f"Joining remaining results as-is.", flush=True)
+        break
+
+    # Safety cap on rounds
+    if consolidation_round >= MAX_CONSOLIDATION_ROUNDS:
+        print(f"  Hit max consolidation rounds ({{MAX_CONSOLIDATION_ROUNDS}}). "
+              f"Joining {{len(batch_results)}} remaining results as-is.", flush=True)
+        break
+
+# Join whatever we have — either a single consolidated result or multiple pieces
+final_result = "\\n\\n---\\n\\n".join(batch_results)
 ```
 
 ### Skip Lists for Efficiency

--- a/webapp/packages/api/user-service/dependencies.py
+++ b/webapp/packages/api/user-service/dependencies.py
@@ -177,6 +177,24 @@ async def _execute_agent_code(
                 elif "reasoning_effort" in parameters:
                     # User explicitly disabled reasoning, remove it
                     parameters = {k: v for k, v in parameters.items() if k != "reasoning_effort"}
+        
+        model_info = APP_PROVIDER_CONFIG.get(provider, {}).get("models", {}).get(model, {})
+        model_max = model_info.get("parameters", {}).get("max_tokens", {}).get("max")
+        if model_max and parameters.get("max_tokens", 0) > model_max:
+            parameters = {**parameters, "max_tokens": model_max}
+
+        # Auto-scale timeout based on request complexity when no explicit timeout is set.
+        # Opus with reasoning_effort=high and max_tokens=128000 can legitimately take
+        # 15-25 minutes on Bedrock. A 600s default kills these calls unnecessarily.
+        if timeout is None:
+            max_tokens = parameters.get("max_tokens", 4096)
+            reasoning = parameters.get("reasoning_effort", "disable")
+
+            if reasoning in ("high",) and max_tokens >= 64000:
+                timeout = 1800  # 30 min for heavy reasoning + large output
+            elif reasoning in ("medium", "high") or max_tokens >= 64000:
+                timeout = 1200  # 20 min for moderate complexity
+            # else: falls through to DEFAULT_LLM_TIMEOUT (600s) in llm_service.py
 
         # Auto-scale timeout based on request complexity when no explicit timeout is set.
         # Opus with reasoning_effort=high and max_tokens=128000 can legitimately take

--- a/webapp/packages/api/user-service/dependencies.py
+++ b/webapp/packages/api/user-service/dependencies.py
@@ -150,9 +150,15 @@ async def _execute_agent_code(
         messages: List[Dict[str, Any]],
         parameters: Dict[str, Any],
         tools: Optional[List[Dict[str, Any]]] = None,
+        timeout: Optional[int] = None,
         **kwargs
     ):
-        """Wrapped call_llm that includes user context for API key lookup and applies LLM settings."""
+        """Wrapped call_llm that includes user context for API key lookup and applies LLM settings.
+        
+        Args:
+            timeout: Per-call timeout in seconds. If not set, automatically scaled
+                     based on max_tokens and reasoning_effort to avoid premature timeouts.
+        """
         # Remove user context kwargs if they were passed by generated code
         # (we'll set them explicitly from the outer scope)
         kwargs.pop("user_service", None)
@@ -172,8 +178,21 @@ async def _execute_agent_code(
                     # User explicitly disabled reasoning, remove it
                     parameters = {k: v for k, v in parameters.items() if k != "reasoning_effort"}
 
+        # Auto-scale timeout based on request complexity when no explicit timeout is set.
+        # Opus with reasoning_effort=high and max_tokens=128000 can legitimately take
+        # 15-25 minutes on Bedrock. A 600s default kills these calls unnecessarily.
+        if timeout is None:
+            max_tokens = parameters.get("max_tokens", 4096)
+            reasoning = parameters.get("reasoning_effort", "disable")
+
+            if reasoning in ("high",) and max_tokens >= 64000:
+                timeout = 1800  # 30 min for heavy reasoning + large output
+            elif reasoning in ("medium", "high") or max_tokens >= 64000:
+                timeout = 1200  # 20 min for moderate complexity
+            # else: falls through to DEFAULT_LLM_TIMEOUT (600s) in llm_service.py
+
         ctx_window = get_context_window(provider, model)
-        print(f">>> call_llm {provider}/{model} context_window={ctx_window:,} max_tokens={parameters.get('max_tokens')} temperature={parameters.get('temperature')} reasoning_effort={parameters.get('reasoning_effort')}", flush=True)
+        print(f">>> call_llm {provider}/{model} context_window={ctx_window:,} max_tokens={parameters.get('max_tokens')} temperature={parameters.get('temperature')} reasoning_effort={parameters.get('reasoning_effort')} timeout={timeout or 'default'}", flush=True)
 
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", message="Pydantic serializer warnings")
@@ -186,6 +205,7 @@ async def _execute_agent_code(
                 user_service=user_service,
                 user_id=user_id,
                 user_basic_info=user_basic_info,
+                timeout=timeout,
                 **kwargs
             )
 

--- a/webapp/packages/api/user-service/services/llm_service.py
+++ b/webapp/packages/api/user-service/services/llm_service.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import os
 from config import settings
 from config.provider_config import PROVIDER_CONFIG
 from services.database_service import get_database_service
@@ -16,6 +17,12 @@ ensure_litellm_logging()
 # Configure litellm defaults
 litellm.drop_params = True
 litellm.set_verbose = False
+
+# Default timeout (seconds) for LLM calls. Override with LLM_TIMEOUT_SECONDS env var.
+DEFAULT_LLM_TIMEOUT = int(os.getenv("LLM_TIMEOUT_SECONDS", "600"))
+
+# Max retries on timeout. Override with LLM_TIMEOUT_RETRIES env var.
+MAX_TIMEOUT_RETRIES = int(os.getenv("LLM_TIMEOUT_RETRIES", "0"))
 
 def _extract_response_cost(response_obj: Any) -> Optional[float]:
     standard_logging = None
@@ -46,10 +53,14 @@ async def call_llm(
     user_service: Optional[UserService] = None,
     user_id: Optional[str] = None,
     user_basic_info: Optional[Dict[str, Any]] = None,
+    timeout: Optional[int] = None,
 ) -> Tuple[str, Any]:
     """
     Calls the specified language model using litellm, handling different API styles.
     Returns a tuple of (content, thoughts).
+
+    Args:
+        timeout: Per-call timeout in seconds. Defaults to LLM_TIMEOUT_SECONDS env var (600).
     """
     model_config = PROVIDER_CONFIG.get(provider, {}).get("models", {}).get(model, {})
     api_style = model_config.get("api_style")
@@ -72,6 +83,10 @@ async def call_llm(
 
     if tools:
         kwargs["tools"] = tools
+
+    # Set timeout for the LLM call
+    effective_timeout = timeout or DEFAULT_LLM_TIMEOUT
+    kwargs["timeout"] = effective_timeout
 
     if user_service is None:
         user_service = get_user_service(get_database_service(settings))
@@ -279,61 +294,78 @@ async def call_llm(
         if reasoning_effort != 'disable':
             kwargs['reasoning_effort'] = reasoning_effort
 
-        try:
-            response = await litellm.acompletion(**kwargs)
-        except Exception as e:
-            observability = get_observability_service()
-            
-            # Check for authentication errors and provide user-friendly message
-            error_str = str(e).lower()
-            if "invalid_api_key" in error_str or "authentication" in error_str or "api key" in error_str:
-                key_source = "user-specific" if api_key else "environment variable"
-                error_msg = f"Invalid API key for {provider}. Please check your {key_source} API key in your profile settings."
-                observability.log(
-                    level="ERROR",
-                    event_type="invalid_api_key",
-                    message=error_msg,
-                    user_id=user_id,
-                    metadata={
-                        "provider": provider,
-                        "key_source": key_source,
-                        "original_error": str(e)[:200],
-                    }
-                )
-                raise ValueError(error_msg) from e
-            
-            # Check for context window overflow errors
-            if "prompt is too long" in error_str or "context_length_exceeded" in error_str or "maximum context length" in error_str:
-                context_window = model_config.get("context_window", "unknown")
-                error_msg = (
-                    f"Prompt exceeded {model}'s context window of {context_window} tokens. "
-                    f"Use hierarchical consolidation to process data in smaller groups."
-                )
-                observability.log(
-                    level="ERROR",
-                    event_type="context_window_exceeded",
-                    message=error_msg,
-                    user_id=user_id,
-                    metadata={
-                        "provider": provider,
-                        "model": model,
-                        "context_window": context_window,
-                        "original_error": str(e)[:500],
-                    }
-                )
-                raise ValueError(error_msg) from e
+        last_exception = None
+        for attempt in range(1 + MAX_TIMEOUT_RETRIES):
+            try:
+                response = await litellm.acompletion(**kwargs)
+                break  # Success
+            except litellm.Timeout as e:
+                last_exception = e
+                if attempt < MAX_TIMEOUT_RETRIES:
+                    wait_secs = 5 * (attempt + 1)
+                    print(
+                        f"  Timeout on attempt {attempt + 1}/{1 + MAX_TIMEOUT_RETRIES} "
+                        f"for {model_string} (timeout={effective_timeout}s). "
+                        f"Retrying in {wait_secs}s...",
+                        flush=True,
+                    )
+                    await asyncio.sleep(wait_secs)
+                    continue
+                # Final attempt failed — fall through to error handling
+                raise
+            except Exception as e:
+                observability = get_observability_service()
+                
+                # Check for authentication errors and provide user-friendly message
+                error_str = str(e).lower()
+                if "invalid_api_key" in error_str or "authentication" in error_str or "api key" in error_str:
+                    key_source = "user-specific" if api_key else "environment variable"
+                    error_msg = f"Invalid API key for {provider}. Please check your {key_source} API key in your profile settings."
+                    observability.log(
+                        level="ERROR",
+                        event_type="invalid_api_key",
+                        message=error_msg,
+                        user_id=user_id,
+                        metadata={
+                            "provider": provider,
+                            "key_source": key_source,
+                            "original_error": str(e)[:200],
+                        }
+                    )
+                    raise ValueError(error_msg) from e
+                
+                # Check for context window overflow errors
+                if "prompt is too long" in error_str or "context_length_exceeded" in error_str or "maximum context length" in error_str:
+                    context_window = model_config.get("context_window", "unknown")
+                    error_msg = (
+                        f"Prompt exceeded {model}'s context window of {context_window} tokens. "
+                        f"Use hierarchical consolidation to process data in smaller groups."
+                    )
+                    observability.log(
+                        level="ERROR",
+                        event_type="context_window_exceeded",
+                        message=error_msg,
+                        user_id=user_id,
+                        metadata={
+                            "provider": provider,
+                            "model": model,
+                            "context_window": context_window,
+                            "original_error": str(e)[:500],
+                        }
+                    )
+                    raise ValueError(error_msg) from e
 
-            observability.log_exception(
-                e,
-                user_id=user_id,
-                metadata={
-                    "context": "litellm.acompletion",
-                    "model": kwargs.get('model'),
-                    "provider": provider,
-                    "tools": kwargs.get('tools'),
-                }
-            )
-            raise
+                observability.log_exception(
+                    e,
+                    user_id=user_id,
+                    metadata={
+                        "context": "litellm.acompletion",
+                        "model": kwargs.get('model'),
+                        "provider": provider,
+                        "tools": kwargs.get('tools'),
+                    }
+                )
+                raise
         message = response.choices[0].message
         content = message.content if isinstance(message.content, str) else ""
         


### PR DESCRIPTION
# Fix LLM timeout failures and infinite consolidation loops

Consolidation calls to Opus 4.6 on Bedrock with `reasoning_effort=high` and `max_tokens=128000` routinely exceed the default 600s LiteLLM timeout. When consolidation fails, the hierarchical consolidation loop puts all results back unchanged, so `len(batch_results)` never decreases and the `while` loop retries forever — each iteration burning another 10 minutes waiting for the same timeout.

## Changes

### `services/llm_service.py`

- Add configurable `timeout` parameter to `call_llm()`, defaulting to `LLM_TIMEOUT_SECONDS` env var (600s)
- Add optional retry on `litellm.Timeout` with configurable `LLM_TIMEOUT_RETRIES` (default 0 — retrying long timeouts just doubles wait time)
- Pass `timeout` through to `litellm.acompletion` kwargs

### `dependencies.py`

- Thread `timeout` parameter through the `call_llm_with_context` wrapper
- Auto-scale timeout based on request complexity: 1800s for `reasoning_effort=high` + `max_tokens >= 64000`, 1200s for moderate complexity, otherwise default
- Log effective timeout in the `>>> call_llm` debug line for observability

### `agent_factory/prompts.py`

- Consolidation template now builds a separate `consolidation_params` dict that strips `reasoning_effort` and caps `max_tokens` at 16384
- Consolidation calls pass `timeout=300` to fail fast
- Add circuit breaker: if a round makes no progress (`len(batch_results) >= prev_count`), break immediately instead of looping forever
- Add `MAX_CONSOLIDATION_ROUNDS = 5` safety cap
- Change `final_result` from `batch_results[0]` to `"\n\n---\n\n".join(batch_results)` so output is preserved even when consolidation fails

## Type of Change

- [x] Other (please describe): Improvements to existing workflow

## Testing

### Test Execution

- [x] All existing tests pass locally

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary (particularly complex areas)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have checked that there are no merge conflicts

## Documentation

- [x] No documentation update needed

---

By submitting this PR, I confirm that I have read and agree to follow the project's [Code of Conduct](https://github.com/the-ai-alliance/gofannon/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/the-ai-alliance/gofannon/blob/main/CONTRIBUTING.md).
